### PR TITLE
Bugno28773106

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/model/AbstractWrapperBeanGenerator.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/model/AbstractWrapperBeanGenerator.java
@@ -224,7 +224,7 @@ public abstract class AbstractWrapperBeanGenerator<T,C,M,A extends Comparable> {
     // Therefore, we are adding a new system property
     // -Dcom.sun.xml.ws.jaxb.allowNonNillableArray=true
     // to implement the behavior requested by the customer.
-    boolean JAXB_ALLOWNONNILLABLEARRAY = getBooleanSystemProperty("com.sun.xml.ws.jaxb.allowNonNillableArray").booleanValue();
+    private final boolean JAXB_ALLOWNONNILLABLEARRAY = getBooleanSystemProperty("com.sun.xml.ws.jaxb.allowNonNillableArray").booleanValue();
 
     /*
      * Process an individual XML element.
@@ -478,8 +478,7 @@ public abstract class AbstractWrapperBeanGenerator<T,C,M,A extends Comparable> {
         return AccessController.doPrivileged(
             new java.security.PrivilegedAction<Boolean>() {
                 public Boolean run() {
-                    String value = System.getProperty(prop);
-                    return value != null ? Boolean.valueOf(value) : Boolean.FALSE;
+                    return Boolean.getBoolean(prop);
                 }
             }
         );

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 package com.sun.tools.ws.test.processor.modeler.annotation;
 
 import com.sun.tools.ws.wscompile.WsgenTool;
@@ -32,6 +42,11 @@ public class NillableArrayTest extends TestCase {
 
         WsgenTool wsgen = new WsgenTool(System.out);
         wsgen.run(options.toArray(new String[options.size()]));
+
+        //resetting system property com.sun.xml.ws.jaxb.allowNonNillableArray
+        //to null as it was before running the testcase 
+        props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","");
+
         try {
             File file = new File(destDir, "NillableTestService_schema1.xsd");
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
@@ -48,8 +63,9 @@ public class NillableArrayTest extends TestCase {
                     Assert.assertNull(complexTypesNodes.item(i).getChildNodes().item(1).getChildNodes().item(1).getAttributes().getNamedItem("nillable"));
                 }
             }
-        } catch(Exception e) {
-            e.printStackTrace();
+        } catch(Exception ex) {
+            fail(ex.getMessage());
+            ex.printStackTrace();
         }
     }
 }

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -64,8 +64,8 @@ public class NillableArrayTest extends TestCase {
                 }
             }
         } catch(Exception ex) {
-            fail(ex.getMessage());
             ex.printStackTrace();
+            fail(ex.getMessage());
         }
     }
 }

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
@@ -1,0 +1,55 @@
+package com.sun.tools.ws.test.processor.modeler.annotation;
+
+import com.sun.tools.ws.wscompile.WsgenTool;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import javax.xml.parsers.DocumentBuilderFactory;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class NillableArrayTest extends TestCase {
+    public void testNillableArray() {
+        File destDir;
+        List<String> options;
+
+        destDir = new File(System.getProperty("java.io.tmpdir"), NillableArrayTest.class.getSimpleName());
+        destDir.mkdirs();
+        options = new ArrayList<>();
+        options.add("-d");
+        options.add(destDir.getAbsolutePath());
+        options.add("-cp");
+        options.add(System.getProperty("java.class.path") + File.pathSeparator + System.getProperty("jdk.module.path"));
+        options.add("com.sun.tools.ws.test.processor.modeler.annotation.NillableTest");
+        options.add("-wsdl");
+
+        Properties props = System.getProperties();
+        props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","true");
+
+        WsgenTool wsgen = new WsgenTool(System.out);
+        wsgen.run(options.toArray(new String[options.size()]));
+        try {
+            File file = new File(destDir, "NillableTestService_schema1.xsd");
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
+            NodeList complexTypesNodes = doc.getElementsByTagName("xs:complexType");
+            for( int i = 0; i < complexTypesNodes.getLength(); i++) {
+
+                //the nillable value is not set so nillable attribute in the schema for that array element will be true
+                if((complexTypesNodes.item(i).getAttributes().getNamedItem("name").getNodeValue()).equals("setEntitlements")) {
+                    Assert.assertEquals("true", complexTypesNodes.item(i).getChildNodes().item(1).getChildNodes().item(1).getAttributes().getNamedItem("nillable").getNodeValue());
+                }
+
+               //the nillable value is set to false so nillable attribute in the schema for that element will be null
+                if((complexTypesNodes.item(i).getAttributes().getNamedItem("name").getNodeValue()).equals("getEntitlementsResponse")) {
+                    Assert.assertNull(complexTypesNodes.item(i).getChildNodes().item(1).getChildNodes().item(1).getAttributes().getNamedItem("nillable"));
+                }
+            }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -30,3 +30,4 @@ public class NillableTest {
                 this.entitlements = entitlements;
         }
 }
+

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 package com.sun.tools.ws.test.processor.modeler.annotation;
 
 import javax.jws.WebService;

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -30,4 +30,3 @@ public class NillableTest {
                 this.entitlements = entitlements;
         }
 }
-

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -1,0 +1,22 @@
+package com.sun.tools.ws.test.processor.modeler.annotation;
+
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+
+@WebService()
+public class NillableTest {
+
+        private java.lang.String[] entitlements;
+
+        @XmlElementWrapper(name="titles")
+        @XmlElement(name="title01", nillable=false)
+        public java.lang.String[] getEntitlements() {
+                return this.entitlements;
+        }
+
+        public void setEntitlements(String[] entitlements) {
+                this.entitlements = entitlements;
+        }
+}


### PR DESCRIPTION
The issue here is that when an element is of an array type, the software currently sets nillable to true regardless of the value of the related annotation.  A customer has complained that nillable="false" should be allowed for such a type.

Since the current behavior was specifically placed in the code, there may be a good reason for it, and we do not want to break compatibility. 
Therefore, we are adding a new system property -Dcom.sun.xml.ws.jaxb.allowNonNillableArray=true to implement the behavior requested by the customer.

Added testcase at 
./jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java 
./jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
