### PR TITLE
Bug28773106branch

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/model/AbstractWrapperBeanGenerator.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/model/AbstractWrapperBeanGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.*;
 import java.util.logging.Logger;
+import java.security.AccessController;
 
 /**
  * Finds request/response wrapper and exception bean memebers.
@@ -212,6 +213,28 @@ public abstract class AbstractWrapperBeanGenerator<T,C,M,A extends Comparable> {
         return responseMembers;
     }
 
+    // When an element is of an array type, the software
+    // currently sets nillable to true regardless of the value of the
+    // related annotation.  A customer has complained that nillable="false"
+    // should be allowed for such a type.
+    //
+    // Since the current behavior was specifically placed in the code,
+    // there may be a good reason for it, and we do not want to break
+    // compatibility.
+    // Therefore, we are adding a new system property
+    // -Dcom.sun.xml.ws.jaxb.allowNonNillableArray=true
+    // to implement the behavior requested by the customer.
+    private final boolean JAXB_ALLOWNONNILLABLEARRAY = getBooleanSystemProperty("com.sun.xml.ws.jaxb.allowNonNillableArray").booleanValue();
+
+    /*
+     * Process an individual XML element.
+     *
+     * @param jaxb List of annotations to search
+     * @param elemName The element to be processed
+     * @param elemNS Namespace for the element
+     * @param type Type of the parameter.  If this is an array type, then the default behavior is to always consider the parameter nillable.  However, if -Dcom.sun.xml.ws.jaxb.allowNonNillableArray=true is set, then an annotation setting nillable to false will be honored.
+     */
+
     private void processXmlElement(List<Annotation> jaxb, String elemName, String elemNS, T type) {
         XmlElement elemAnn = null;
         for (Annotation a : jaxb) {
@@ -227,7 +250,8 @@ public abstract class AbstractWrapperBeanGenerator<T,C,M,A extends Comparable> {
         String ns = (elemAnn != null && !elemAnn.namespace().equals("##default"))
                 ? elemAnn.namespace() : elemNS;
 
-        boolean nillable = nav.isArray(type)
+        boolean nillable = (nav.isArray(type) && !JAXB_ALLOWNONNILLABLEARRAY)
+                || (nav.isArray(type) && elemAnn == null)
                 || (elemAnn != null && elemAnn.nillable());
 
         boolean required = elemAnn != null && elemAnn.required();
@@ -448,6 +472,16 @@ public abstract class AbstractWrapperBeanGenerator<T,C,M,A extends Comparable> {
         reservedWords.put("volatile", "_volatile");
         reservedWords.put("while", "_while");
         reservedWords.put("enum", "_enum");
+    }
+
+    private static Boolean getBooleanSystemProperty(final String prop) {
+        return AccessController.doPrivileged(
+            new java.security.PrivilegedAction<Boolean>() {
+                public Boolean run() {
+                    return Boolean.getBoolean(prop);
+                }
+            }
+        );
     }
 
 }

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.tools.ws.test.processor.modeler.annotation;
+
+import com.sun.tools.ws.wscompile.WsgenTool;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import javax.xml.parsers.DocumentBuilderFactory;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class NillableArrayTest extends TestCase {
+    public void testNillableArray() {
+        File destDir;
+        List<String> options;
+
+        destDir = new File(System.getProperty("java.io.tmpdir"), NillableArrayTest.class.getSimpleName());
+        destDir.mkdirs();
+        options = new ArrayList<>();
+        options.add("-d");
+        options.add(destDir.getAbsolutePath());
+        options.add("-cp");
+        options.add(System.getProperty("java.class.path") + File.pathSeparator + System.getProperty("jdk.module.path"));
+        options.add("com.sun.tools.ws.test.processor.modeler.annotation.NillableTest");
+        options.add("-wsdl");
+
+        Properties props = System.getProperties();
+        props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","true");
+
+        WsgenTool wsgen = new WsgenTool(System.out);
+        wsgen.run(options.toArray(new String[options.size()]));
+
+        //resetting system property com.sun.xml.ws.jaxb.allowNonNillableArray
+        //to null as it was before running the testcase 
+        props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","");
+
+        try {
+            File file = new File(destDir, "NillableTestService_schema1.xsd");
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
+            NodeList complexTypesNodes = doc.getElementsByTagName("xs:complexType");
+            for( int i = 0; i < complexTypesNodes.getLength(); i++) {
+
+                //the nillable value is not set so nillable attribute in the schema for that array element will be true
+                if((complexTypesNodes.item(i).getAttributes().getNamedItem("name").getNodeValue()).equals("setEntitlements")) {
+                    Assert.assertEquals("true", complexTypesNodes.item(i).getChildNodes().item(1).getChildNodes().item(1).getAttributes().getNamedItem("nillable").getNodeValue());
+                }
+
+               //the nillable value is set to false so nillable attribute in the schema for that element will be null
+                if((complexTypesNodes.item(i).getAttributes().getNamedItem("name").getNodeValue()).equals("getEntitlementsResponse")) {
+                    Assert.assertNull(complexTypesNodes.item(i).getChildNodes().item(1).getChildNodes().item(1).getAttributes().getNamedItem("nillable"));
+                }
+            }
+        } catch(Exception ex) {
+            ex.printStackTrace();
+            fail(ex.getMessage());
+        }
+    }
+}

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
@@ -19,7 +19,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 public class NillableArrayTest extends TestCase {
@@ -34,21 +33,17 @@ public class NillableArrayTest extends TestCase {
         options.add(destDir.getAbsolutePath());
         options.add("-cp");
         options.add(System.getProperty("java.class.path") + File.pathSeparator + System.getProperty("jdk.module.path"));
-        options.add("com.sun.tools.ws.test.processor.modeler.annotation.NillableTest");
+        options.add("com.sun.tools.ws.test.processor.modeler.annotation.NillableTestWs");
         options.add("-wsdl");
 
         Properties props = System.getProperties();
         props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","true");
 
         WsgenTool wsgen = new WsgenTool(System.out);
-        wsgen.run(options.toArray(new String[options.size()]));
-
-        //resetting system property com.sun.xml.ws.jaxb.allowNonNillableArray
-        //to null as it was before running the testcase 
-        props.setProperty("com.sun.xml.ws.jaxb.allowNonNillableArray","");
 
         try {
-            File file = new File(destDir, "NillableTestService_schema1.xsd");
+            wsgen.run(options.toArray(new String[options.size()]));
+            File file = new File(destDir, "NillableTestWsService_schema1.xsd");
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
             NodeList complexTypesNodes = doc.getElementsByTagName("xs:complexType");
             for( int i = 0; i < complexTypesNodes.getLength(); i++) {
@@ -66,6 +61,8 @@ public class NillableArrayTest extends TestCase {
         } catch(Exception ex) {
             ex.printStackTrace();
             fail(ex.getMessage());
+        } finally{
+            System.clearProperty("com.sun.xml.ws.jaxb.allowNonNillableArray");
         }
     }
 }

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.tools.ws.test.processor.modeler.annotation;
+
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+
+@WebService()
+public class NillableTest {
+
+        private java.lang.String[] entitlements;
+
+        @XmlElementWrapper(name="titles")
+        @XmlElement(name="title01", nillable=false)
+        public java.lang.String[] getEntitlements() {
+                return this.entitlements;
+        }
+
+        public void setEntitlements(String[] entitlements) {
+                this.entitlements = entitlements;
+        }
+}

--- a/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTestWs.java
+++ b/jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTestWs.java
@@ -12,11 +12,10 @@ package com.sun.tools.ws.test.processor.modeler.annotation;
 
 import javax.jws.WebService;
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 
 @WebService()
-public class NillableTest {
+public class NillableTestWs {
 
         private java.lang.String[] entitlements;
 


### PR DESCRIPTION
The issue here is that when an element is of an array type, the software currently sets nillable to true regardless of the value of the related annotation. A customer has complained that nillable="false" should be allowed for such a type.

Since the current behavior was specifically placed in the code, there may be a good reason for it, and we do not want to break compatibility.
Therefore, we are adding a new system property -Dcom.sun.xml.ws.jaxb.allowNonNillableArray=true to implement the behavior requested by the customer.

Added testcase at
./jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableArrayTest.java
./jaxws-ri/tools/wscompile/src/test/java/com/sun/tools/ws/test/processor/modeler/annotation/NillableTest.java