### PR TITLE
Bug29851244branch

### DIFF
--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -53,8 +53,8 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         writer.writeStartDocument();
     }
 
-    private boolean isWhiteSpace(char c){
-        // all char points between 0 and 31 excluding the allowed white spaces (9=TAB, 10=LF, 13=CR)
+    private boolean isUnusualChar(char c){
+        // all char points between 0 and 31 excluding the allowed white spaces (9=\t, 10=\n, 13=\r)
         if (c >= 0 && c<=31 && c != 9 && c != 10 && c != 13)
                 return true;
 
@@ -65,7 +65,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         char[] cstr = text.toCharArray();
         StringBuffer sb = new StringBuffer();
         for(char c:cstr){
-                if(isWhiteSpace(c))
+                if(isUnusualChar(c))
                         sb.append("&#").append(Integer.toString(c)).append(";");
                 else
                         sb.append(c);

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -62,7 +62,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
 
     private String transformWhiteSpaces(String text){
         char[] cstr = text.toCharArray();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for(char c:cstr){
                 if(isUnusualChar(c))
                         sb.append("&#").append(Integer.toString(c)).append(";");
@@ -72,7 +72,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         return sb.toString();
     }
 
-    private char[] transformWhiteSpaces(char[] text, int start, int len){
+    private void transformWhiteSpaces(char[] text, int start, int len){
         for(int i=0; i<len; i++){
                 if (i+start >= text.length){
                         break;
@@ -80,11 +80,10 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
                 if(isUnusualChar(text[i]))
                         text[i] = ' '; //change it to ' '
         }
-        return text;
     }
 
     public void writeCharacters(char[] text, int start, int len) throws XMLStreamException {
-        text = transformWhiteSpaces(text, start, len);
+        transformWhiteSpaces(text, start, len);
         writer.writeCharacters(text, start, len);
     }
 

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -54,7 +54,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
     }
 
     private boolean isUnusualChar(char c){
-        if (c<=31 && c != '\t' && c != '\n' && c != '\r')
+        if ((c<=31) && (c != '\t') && (c != '\n') && (c != '\r'))
                 return true;
 
         return false;
@@ -72,7 +72,19 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         return sb.toString();
     }
 
+    private char[] transformWhiteSpaces(char[] text, int start, int len){
+        for(int i=0; i<len; i++){
+                if (i+start >= text.length){
+                        break;
+                }
+                if(isUnusualChar(text[i]))
+                        text[i] = ' '; //change it to ' '
+        }
+        return text;
+    }
+
     public void writeCharacters(char[] text, int start, int len) throws XMLStreamException {
+        text = transformWhiteSpaces(text, start, len);
         writer.writeCharacters(text, start, len);
     }
 

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -53,6 +53,26 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         writer.writeStartDocument();
     }
 
+    private boolean isWhiteSpace(char c){
+        // all char points between 0 and 31 excluding the allowed white spaces (9=TAB, 10=LF, 13=CR)
+        if (c >= 0 && c<=31 && c != 9 && c != 10 && c != 13)
+                return true;
+
+        return false;
+    }
+
+    private String transformWhiteSpaces(String text){
+        char[] cstr = text.toCharArray();
+        StringBuffer sb = new StringBuffer();
+        for(char c:cstr){
+                if(isWhiteSpace(c))
+                        sb.append("&#").append(Integer.toString(c)).append(";");
+                else
+                        sb.append(c);
+        }
+        return sb.toString();
+    }
+
     public void writeCharacters(char[] text, int start, int len) throws XMLStreamException {
         writer.writeCharacters(text, start, len);
     }
@@ -66,6 +86,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
     }
 
     public void writeCharacters(String text) throws XMLStreamException {
+        text = transformWhiteSpaces(text);
         writer.writeCharacters(text);
     }
 

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -53,35 +53,34 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         writer.writeStartDocument();
     }
 
-    private boolean isUnusualChar(char c){
+    private boolean isUnusualChar(char c) {
         if ((c<=31) && (c != '\t') && (c != '\n') && (c != '\r')) {
-                return true;
+            return true;
         }
-
         return false;
     }
 
-    private String transformWhiteSpaces(String text){
+    private String transformWhiteSpaces(String text) {
         char[] cstr = text.toCharArray();
         StringBuilder sb = new StringBuilder();
-        for(char c:cstr){
-                if(isUnusualChar(c)) {
-                        sb.append("&#").append(Integer.toString(c)).append(";");
-                } else {
-                        sb.append(c);
-                }
+        for (char c:cstr) {
+            if (isUnusualChar(c)) {
+                sb.append("&#").append(Integer.toString(c)).append(";");
+            } else {
+                sb.append(c);
+            }
         }
         return sb.toString();
     }
 
-    private void transformWhiteSpaces(char[] text, int start, int len){
-        for(int i=0; i<len; i++){
-                if (i+start >= text.length) {
-                        break;
-                }
-                if(isUnusualChar(text[i])) {
-                        text[i] = ' '; //change it to ' '
-                }
+    private void transformWhiteSpaces(char[] text, int start, int len) {
+        for (int i=0; i<len; i++) {
+            if (i+start >= text.length) {
+                break;
+            }
+            if (isUnusualChar(text[i])) {
+                text[i] = ' '; //change it to ' '
+            }
         }
     }
 

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -54,8 +54,7 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
     }
 
     private boolean isUnusualChar(char c){
-        // all char points between 0 and 31 excluding the allowed white spaces (9=\t, 10=\n, 13=\r)
-        if (c >= 0 && c<=31 && c != 9 && c != 10 && c != 13)
+        if (c<=31 && c != '\t' && c != '\n' && c != '\r')
                 return true;
 
         return false;

--- a/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
+++ b/jaxws-ri/rt/src/main/java/com/sun/xml/ws/util/xml/XMLStreamWriterFilter.java
@@ -54,8 +54,9 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
     }
 
     private boolean isUnusualChar(char c){
-        if ((c<=31) && (c != '\t') && (c != '\n') && (c != '\r'))
+        if ((c<=31) && (c != '\t') && (c != '\n') && (c != '\r')) {
                 return true;
+        }
 
         return false;
     }
@@ -64,21 +65,23 @@ public class XMLStreamWriterFilter implements XMLStreamWriter, RecycleAware {
         char[] cstr = text.toCharArray();
         StringBuilder sb = new StringBuilder();
         for(char c:cstr){
-                if(isUnusualChar(c))
+                if(isUnusualChar(c)) {
                         sb.append("&#").append(Integer.toString(c)).append(";");
-                else
+                } else {
                         sb.append(c);
+                }
         }
         return sb.toString();
     }
 
     private void transformWhiteSpaces(char[] text, int start, int len){
         for(int i=0; i<len; i++){
-                if (i+start >= text.length){
+                if (i+start >= text.length) {
                         break;
                 }
-                if(isUnusualChar(text[i]))
+                if(isUnusualChar(text[i])) {
                         text[i] = ' '; //change it to ' '
+                }
         }
     }
 

--- a/jaxws-ri/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJMessageTest.java
+++ b/jaxws-ri/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJMessageTest.java
+++ b/jaxws-ri/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJMessageTest.java
@@ -118,9 +118,13 @@ public class SAAJMessageTest extends TestCase {
         MessageFactory messageFactory = MessageFactory.newInstance();
         SOAPMessage message = messageFactory.createMessage();
         SOAPBody body = message.getSOAPBody();
-        QName name = new QName("testString");
+        QName name = new QName("testString1");
         SOAPBodyElement bodyElement = body.addBodyElement(name);
         bodyElement.addTextNode("Hello World, ---\003\007\024---");
+
+        name = new QName("testString2");
+        bodyElement = body.addBodyElement(name);
+        bodyElement.addTextNode("Hello \t\n\r World");
 
         SAAJMessage saajMsg = new SAAJMessage(message);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -129,8 +133,10 @@ public class SAAJMessageTest extends TestCase {
         writer.close();
 
         Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse( new InputSource( new StringReader( baos.toString() ) ) );
-        NodeList nodeList = doc.getElementsByTagName("testString");
+        NodeList nodeList = doc.getElementsByTagName("testString1");
         assertEquals(nodeList.item(0).getFirstChild().getNodeValue(), "Hello World, ---&#3;&#7;&#20;---");
+        nodeList = doc.getElementsByTagName("testString2");
+        assertEquals(nodeList.item(0).getFirstChild().getNodeValue(), "Hello \t\n\r World");
     }
 
     public void testFirstDetailEntryName() throws Exception {


### PR DESCRIPTION
When the SAAJ message contains unusual characters then it gives unexpected partial response 
due to following woodstox exception
Caused by: com.ctc.wstx.exc.WstxIOException: Invalid white space character
(0x3) in text to output (in xml 1.1, could output as a character entity)

So in the fix I have encoded all unusual characters which can give those exceptions

Added testcase method testWhiteSpaceCharacters() at 
./jaxws-ri/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJMessageTest.java