### PR TITLE
Avoid creating empty directories in unexpected locations by wsgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,4 @@ java_pid*
 # vi backup file
 *~
 
-/jaxws-ri/tools/wscompile/com
-/jaxws-ri/tools/wscompile/jaxws
-
 work/

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/annotation/WebServiceWrapperGenerator.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/annotation/WebServiceWrapperGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -29,10 +29,7 @@ import com.sun.tools.jxc.ap.InlineAnnotationReaderImpl;
 import com.sun.tools.jxc.model.nav.ApNavigator;
 import com.sun.tools.ws.ToolVersion;
 import com.sun.tools.ws.processor.generator.GeneratorBase;
-import com.sun.tools.ws.processor.generator.GeneratorConstants;
-import com.sun.tools.ws.processor.generator.Names;
 import com.sun.tools.ws.processor.modeler.ModelerException;
-import com.sun.tools.ws.processor.util.DirectoryUtil;
 import com.sun.tools.ws.resources.WebserviceapMessages;
 import com.sun.tools.ws.util.ClassNameInfo;
 import com.sun.tools.ws.wscompile.FilerCodeWriter;
@@ -68,7 +65,6 @@ import javax.xml.ws.RequestWrapper;
 import javax.xml.ws.ResponseWrapper;
 import javax.xml.ws.WebFault;
 import javax.xml.ws.WebServiceException;
-import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -231,9 +227,6 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
                 reqNamespace = reqWrapper.targetNamespace();
         }
         builder.log("requestWrapper: "+requestClassName);
-///// fix for wsgen CR 6442344
-        addGeneratedFile(requestClassName);
-//////////
         boolean canOverwriteRequest = builder.canOverWriteClass(requestClassName);
         if (!canOverwriteRequest) {
             builder.log("Class " + requestClassName + " exists. Not overwriting.");
@@ -257,6 +250,7 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
                     resNamespace = resWrapper.targetNamespace();
             }
             canOverwriteResponse = builder.canOverWriteClass(responseClassName);
+            builder.log("responseWrapper: " + responseClassName);
             if (!canOverwriteResponse) {
                 builder.log("Class " + responseClassName + " exists. Not overwriting.");
             }
@@ -264,7 +258,6 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
                 builder.processError(WebserviceapMessages.WEBSERVICEAP_METHOD_RESPONSE_WRAPPER_BEAN_NAME_NOT_UNIQUE(
                         typeElement.getQualifiedName(), method.toString()));
             }
-            addGeneratedFile(responseClassName);
         }
         //ArrayList<MemberInfo> reqMembers = new ArrayList<MemberInfo>();
         //ArrayList<MemberInfo> resMembers = new ArrayList<MemberInfo>();
@@ -312,12 +305,6 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
             throw new ModelerException("modeler.nestedGeneratorError",e);
         }
         return true;
-    }
-
-    private void addGeneratedFile(String requestClassName) {
-        File file = new File(DirectoryUtil.getOutputDirectoryFor(requestClassName, builder.getSourceDir()),
-                Names.stripQualifier(requestClassName) + GeneratorConstants.JAVA_SRC_SUFFIX.getValue());
-        builder.getOptions().addGeneratedFile(file);
     }
 
 //    private List<Annotation> collectJAXBAnnotations(Declaration decl) {
@@ -443,6 +430,7 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
                         webFault.faultBean() : className;
 
         }
+        builder.log("exceptionBean: " + className);
         JDefinedClass cls = getCMClass(className, CLASS);
         faultInfo = new FaultInfo(className, false);
 
@@ -460,8 +448,6 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
         if (seiContext.getExceptionBeanName(thrownDecl.getQualifiedName()) != null) {
             return false;
         }
-
-        addGeneratedFile(className);
 
         //write class comment - JAXWS warning
         JDocComment comment = cls.javadoc();
@@ -555,5 +541,4 @@ public class WebServiceWrapperGenerator extends WebServiceVisitor {
         body = m.body();
         body.assign( JExpr._this().ref(paramName), param );
     }
-}      
-    
+}

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/wscompile/Options.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/wscompile/Options.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -25,6 +25,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import javax.tools.FileObject;
 
 /**
  * Provide common jaxws tool options.
@@ -47,13 +48,10 @@ public class Options {
      */
     public boolean keep;
 
-    
-
     /**
      * -d
      */
     public File destDir = new File(".");
-
 
     /**
      * -s
@@ -74,11 +72,10 @@ public class Options {
 
     /**
      * -javacOptions
-     * 
+     *
      * @since 2.2.9
      */
     public List<String> javacOptions;
-
 
     /**
      * -Xnocompile
@@ -142,7 +139,7 @@ public class Options {
         public static Target getLoadedAPIVersion() {
             return LOADED_API_VERSION;
         }
-        
+
         private static final Target LOADED_API_VERSION;
 
         static {
@@ -196,11 +193,25 @@ public class Options {
 
 
     /**
-     * Remember info on  generated source file generated so that it
+     * Remember info on generated source file so that it
      * can be removed later, if appropriate.
+     *
+     * @param file generated File
+     *
+     * @deprecated Use {@link #addGeneratedFile(javax.tools.FileObject) } instead.
      */
+    @Deprecated
     public void addGeneratedFile(File file) {
         generatedFiles.add(file);
+    }
+
+    /**
+     * Remember info on generated file so that it can be removed later, if appropriate.
+     *
+     * @param fo generated FileObject
+     */
+    public void addGeneratedFile(FileObject fo) {
+        generatedFiles.add(new File(fo.toUri()));
     }
 
     /**
@@ -215,7 +226,7 @@ public class Options {
                 }
             }
         }
-        generatedFiles.clear();        
+        generatedFiles.clear();
     }
 
     /**


### PR DESCRIPTION
When annotation processor is run directly ie through javac using maven-compiler-plugin, empty directories representing package structure of files to be generated gets created under `${project.basedir}` which is wrong. Problem is that the call to `DirectoryUtil.getOutputDirectoryFor` always creates non-existing dirs. Solution is to start tracking to be created files at the point they are actually created (by `FilerCodeWriter`) instead of  right after the name of the to be created file becomes known.

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>