### PR TITLE
Re-apply source fix for JDK-8186441

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/api/message/saaj/SaajStaxWriter.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/api/message/saaj/SaajStaxWriter.java
@@ -484,7 +484,7 @@ public class SaajStaxWriter implements XMLStreamWriter {
                     }
                     // add namespace declarations
                     for (NamespaceDeclaration namespace : this.namespaceDeclarations) {
-                        target.addNamespaceDeclaration(namespace.prefix, namespace.namespaceUri);
+                        newElement.addNamespaceDeclaration(namespace.prefix, namespace.namespaceUri);
                     }
                     // add attribute declarations
                     for (AttributeDeclaration attribute : this.attributeDeclarations) {


### PR DESCRIPTION
In 2017, Aleks Efimov put in a fix for to the javaee/metro-saaj repository to fix a problem where namespace declarations were getting added to parent elements incorrectly (JDK-8186441). This fix seems to have gotten lost in the eclipse-ee4j/metro-jax-ws repository, and we saw a regression when moving to this version, so this change is just to re-apply the fix.

For details see:
http://openjdk.5641.n7.nabble.com/10-RFR-8186441-Change-of-behavior-in-the-getMessage-method-of-the-SOAPMessageContextImpl-class-td320585.html
and the original pull request:
https://github.com/javaee/metro-saaj/pull/92/commits/8267e08a8a26138f0223bb86dfe599e69f0af28d