### PR TITLE
Re-apply source fix for JDK-8186441

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/api/message/saaj/SaajStaxWriter.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/api/message/saaj/SaajStaxWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -484,7 +484,7 @@ public class SaajStaxWriter implements XMLStreamWriter {
                     }
                     // add namespace declarations
                     for (NamespaceDeclaration namespace : this.namespaceDeclarations) {
-                        target.addNamespaceDeclaration(namespace.prefix, namespace.namespaceUri);
+                        newElement.addNamespaceDeclaration(namespace.prefix, namespace.namespaceUri);
                     }
                     // add attribute declarations
                     for (AttributeDeclaration attribute : this.attributeDeclarations) {

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJFactoryTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/message/saaj/SAAJFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -139,7 +139,7 @@ public class SAAJFactoryTest extends TestCase {
         XMLStreamReader envelope = inputFactory.createXMLStreamReader(new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body>" +
-                "<SampleServiceRequest xmlns=\"http://sample.ex.org/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+                "<SampleServiceRequest xmlns=\"http://sample.ex.org/\">" +
                 "<RequestParams xmlns=\"\">" +
                 "<Param1>hogehoge</Param1>" +
                 "<Param2>fugafuga</Param2>" +
@@ -193,7 +193,7 @@ public class SAAJFactoryTest extends TestCase {
         XMLStreamReader envelope = inputFactory.createXMLStreamReader(new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
                 "<s:Body>" +
-                "<SampleServiceRequest xmlns=\"http://sample.ex.org/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+                "<SampleServiceRequest xmlns=\"http://sample.ex.org/\">" +
                 "<RequestParams xmlns=\"\">" +
                 "<Param1>hogehoge</Param1>" +
                 "<Param2>fugafuga</Param2>" +


### PR DESCRIPTION
In 2017, Aleks Efimov put in a fix for to the javaee/metro-saaj repository to fix a problem where namespace declarations were getting added to parent elements incorrectly (JDK-8186441). This fix seems to have gotten lost in the eclipse-ee4j/metro-jax-ws repository, so this change is just to re-apply the fix.

For details see:
http://openjdk.5641.n7.nabble.com/10-RFR-8186441-Change-of-behavior-in-the-getMessage-method-of-the-SOAPMessageContextImpl-class-td320585.html
and the original pull request:
https://github.com/javaee/metro-saaj/pull/92/commits/8267e08a8a26138f0223bb86dfe599e69f0af28d

Signed-off-by: Brian Delaney <briandelaney@google.com>