### PR TITLE
wsgen.sh fix for JAVA_HOME variables with spaces

### DIFF
--- a/jaxws-ri/bundles/jaxws-ri/src/main/resources/bin/wsgen.sh
+++ b/jaxws-ri/bundles/jaxws-ri/src/main/resources/bin/wsgen.sh
@@ -54,4 +54,4 @@ else
 fi
 
 
-exec $JAVA $WSGEN_OPTS -cp "$JAXWS_HOME/lib/jaxws-tools.jar" com.sun.tools.ws.WsGen "$@"
+exec "$JAVA" $WSGEN_OPTS -cp "$JAXWS_HOME/lib/jaxws-tools.jar" com.sun.tools.ws.WsGen "$@"


### PR DESCRIPTION
wsimport.sh it working fine. The issue is happening in wsgen.sh.

> jbescos@JBESCOS-CZ /cygdrive/c/workspaceJAXB/metro-jax-ws/jaxws-ri/bundles/jaxws-ri/src/main/resources/bin
> $ ./wsgen.sh
> ./wsgen.sh: line 57: exec: C:\Program: not found


Now it will be success with that error:

> jbescos@JBESCOS-CZ /cygdrive/c/workspaceJAXB/metro-jax-ws/jaxws-ri/bundles/jaxws-ri/src/main/resources/bin
> $ ./wsgen.sh
> Error: Could not find or load main class com.sun.tools.ws.WsGen

