### PR TITLE
JAX_WS-1175: Issue #95 - fix method call by reflection

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/assembler/MetroConfigLoader.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/assembler/MetroConfigLoader.java
@@ -343,6 +343,7 @@ class MetroConfigLoader {
                     }
                     try {
                         final Method method = context.getClass().getMethod("getResource", String.class);
+                        method.setAccessible(true);
                         final Object result = method.invoke(context, "/WEB-INF/" + resource);
                         return URL.class.cast(result);
                     } catch (Exception e) {


### PR DESCRIPTION
Fix for [https://github.com/eclipse-ee4j/metro-jax-ws/issues/95](https://github.com/eclipse-ee4j/metro-jax-ws/issues/95)

torstenwerner put this fix in old repository to get rid of the problem, where "getResource" method from private nested class (used in Tomcat) is called by reflection 