### PR TITLE
Do not create a new DelegatingLoader if the classloader for the proxy…

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/client/WSServiceDelegate.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/client/WSServiceDelegate.java
@@ -884,14 +884,15 @@ public class WSServiceDelegate extends WSService {
     private static ClassLoader getDelegatingLoader(ClassLoader loader1, ClassLoader loader2) {
     	if (loader1 == null) return loader2;
     	if (loader2 == null) return loader1;
-        //If there is already a parent-child relationship between loaders,
-        //it does not make sense to create a new one
-        //The created proxy might be reusable, otherwise a new proxy is 
-        //created on each call since a new loader is used each time
-        ClassLoader parent = loader1.getParent();
-        while (parent != null) {
-           if (parent == loader2) return loader1;
-           parent = parent.getParent();
+
+      //If there is already a parent-child relationship between loaders,
+      //it does not make sense to create a new one
+      //The created proxy might be reusable, otherwise a new proxy is
+      //created on each call since a new loader is used each time
+      ClassLoader parent = loader1;
+      while (parent != null) {
+         if (parent == loader2) return loader1;
+         parent = parent.getParent();
     	}
     	return new DelegatingLoader(loader1, loader2);
     }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/client/WSServiceDelegate.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/client/WSServiceDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/client/WSServiceDelegateTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/client/WSServiceDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/client/WSServiceDelegateTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/client/WSServiceDelegateTest.java
@@ -19,7 +19,10 @@ public class WSServiceDelegateTest extends TestCase {
         MyClassLoader loader1 = new MyClassLoader(loader2);
         ClassLoader result = invokeGetDelegatingLoader(loader1, loader2);
         assertEquals(loader1, result);
-        
+
+        result = invokeGetDelegatingLoader(loader1, loader1);
+        assertEquals(loader1, result);
+
         loader2 = new MyClassLoader();
         loader1 = new MyClassLoader();
         result = invokeGetDelegatingLoader(loader1, loader2);


### PR DESCRIPTION
… interface and the classloader for the WSServiceDelegate are the same.

This should alleviate some cases of https://github.com/javaee/metro-jax-ws/issues/1161 and https://github.com/eclipse-ee4j/metro-jax-ws/issues/32, where we see additional metaspace usage from loading proxies in different instances of DelegatingLoader class loaders every time they are created even though WSServiceDelegate and the proxy interface are loaded in the same classloader.

Signed-off-by: Brian Delaney <briandelaney@google.com>