### PR TITLE
import of jdk specific class must be optional in osgi

### DIFF
--- a/jaxws-ri/bundles/jaxws-rt/pom.xml
+++ b/jaxws-ri/bundles/jaxws-rt/pom.xml
@@ -300,6 +300,7 @@
                                     javax.servlet.*;version=!;resolution:=optional,
                                     javax.xml.catalog;resolution:=optional,
                                     sun.misc;resolution:=optional,
+                                    jdk.internal.misc;resolution:=optional,
                                     *
                                 </Import-Package>
                                 <Multi-Release>true</Multi-Release>


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>