### PR TITLE
make sure policy builds sources jar by default

### DIFF
--- a/jaxws-ri/runtime/policy/pom.xml
+++ b/jaxws-ri/runtime/policy/pom.xml
@@ -377,6 +377,14 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>