### PR TITLE
Bugno31091695

### DIFF
--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.wsdl.writer;
+
+import java.io.*;
+import java.net.URL;
+import java.util.Properties;
+import javax.xml.parsers.DocumentBuilderFactory;
+import jakarta.xml.ws.Endpoint;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+import com.sun.xml.ws.api.BindingID;
+import com.sun.xml.ws.transport.http.server.EndpointImpl;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import java.nio.file.*;
+
+public class PublishWSDLTest extends TestCase {
+
+    public void testPublishWSDL() {
+        PublishWSDLTestWs service = new PublishWSDLTestWs();
+        String address = "http://localhost:9999/hello";
+        Endpoint endpoint = new EndpointImpl(BindingID.parse(service.getClass()), service);
+        endpoint.publish(address);
+        Properties props = System.getProperties();
+        props.setProperty("com.sun.xml.ws.wsdl.externalSchemaLocationURL","true");
+        try {
+            URL wsdlUrl = new URL(address+"?wsdl");
+            InputStream in = wsdlUrl.openStream();
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(in);
+            NodeList importNodes = doc.getElementsByTagName("xsd:import");
+            Assert.assertEquals("PublishWSDLTestWsService_schema1.xsd", importNodes.item(0).getAttributes().getNamedItem("schemaLocation").getNodeValue());
+            endpoint.stop();
+        } catch(Exception ex) {
+            ex.printStackTrace();
+            fail(ex.getMessage());
+        } finally{
+            System.clearProperty("com.sun.xml.ws.wsdl.externalSchemaLocationURL");
+        }
+    }
+} 

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTestWs.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTestWs.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.wsdl.writer;
+
+import jakarta.jws.WebService;
+
+@WebService
+public class PublishWSDLTestWs {
+
+    public String getHelloWorldAsString(String name) {
+        return "Hello " + name;
+    }
+} 


### PR DESCRIPTION
The schemaLocation of the xsd import in the wsdl generated by JAXWS-RI 
is replaced by the actual host:port URL of the server where the webservice is deployed

This is how webservice is designed but the customer has a requirement where they do not 
want the absolute location of the schemaLocation to be replaced by host:port URL of the server

Therefore, we are adding a new system property -Dcom.sun.xml.ws.wsdl.externalSchemaLocationURL=true 
to implement the behavior requested by the customer

Added testcase at

./jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTestWs.java
./jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/wsdl/writer/PublishWSDLTest.java