### PR TITLE
SOAP JAX-WS VERBOSE ERROR MESSAGES

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/streaming/XMLStreamReaderUtil.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/streaming/XMLStreamReaderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -293,7 +293,8 @@ public class XMLStreamReaderUtil {
     }
     
     private static XMLStreamReaderException wrapException(XMLStreamException e) {
-        return new XMLStreamReaderException("xmlreader.ioException",e);
+        // https://github.com/eclipse-ee4j/metro-jax-ws/issues/156
+        return new XMLStreamReaderException("xmlreader.ioException", e.getMessage());
     }
 
     // -- Auxiliary classes ----------------------------------------------

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/streaming/XMLReaderCompositeTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/streaming/XMLReaderCompositeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -64,6 +64,20 @@ public class XMLReaderCompositeTest extends TestCase {
 
         xrc.next();
         assertTrue(xrc.isEndElement());
+    }
+
+    public void testInvalidXML() throws Exception {
+        XMLInputFactory fac = XMLInputFactory.newFactory();
+        ByteArrayInputStream in = new ByteArrayInputStream("test".getBytes());
+        XMLStreamReader r = fac.createXMLStreamReader(in);
+        try {
+            XMLStreamReaderUtil.readRest(r);
+            fail("Exception should be thrown");
+        } catch (Exception e) {
+            assertEquals("XML reader error: Unexpected character 't' (code 116) in prolog; expected '<'\n" + 
+                    " at [row,col {unknown-source}]: [1,1]", e.getMessage());
+        }
+
     }
 
     private XMLStreamReader r(String msg) throws XMLStreamException {


### PR DESCRIPTION
Relates to this issue: https://github.com/eclipse-ee4j/metro-jax-ws/issues/156