### PR TITLE
Expose setAuthenticator on HTTPUrlConnection

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/transport/http/client/HttpClientTransport.java
+++ b/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/transport/http/client/HttpClientTransport.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.transport.http.client;
+
+import com.sun.xml.ws.api.EndpointAddress;
+import com.sun.xml.ws.api.message.Packet;
+import com.sun.xml.ws.client.BindingProviderProperties;
+import static com.sun.xml.ws.client.BindingProviderProperties.*;
+import com.sun.xml.ws.client.ClientTransportException;
+import com.sun.xml.ws.resources.ClientMessages;
+import com.sun.xml.ws.transport.Headers;
+import com.sun.xml.ws.developer.JAXWSProperties;
+import com.sun.istack.Nullable;
+import com.sun.istack.NotNull;
+
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.ws.WebServiceException;
+import javax.xml.ws.handler.MessageContext;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.GZIPInputStream;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ *
+ * @author WS Development Team
+ */
+public class HttpClientTransport {
+
+    private static final byte[] THROW_AWAY_BUFFER = new byte[8192];
+    
+    // Need to use JAXB first to register DatatypeConverter
+    static {
+        try {
+            JAXBContext.newInstance().createUnmarshaller();
+        } catch(JAXBException je) {
+            // Nothing much can be done. Intentionally left empty
+        }
+    }
+
+    /*package*/ int statusCode;
+    /*package*/ String statusMessage;
+    /*package*/ int contentLength;
+    private final Map<String, List<String>> reqHeaders;
+    private Map<String, List<String>> respHeaders = null;
+
+    private OutputStream outputStream;
+    private boolean https;
+    private HttpURLConnection httpConnection = null;
+    private final EndpointAddress endpoint;
+    private final Packet context;
+    private final Integer chunkSize;
+
+
+    public HttpClientTransport(@NotNull Packet packet, @NotNull Map<String,List<String>> reqHeaders) {
+        endpoint = packet.endpointAddress;
+        context = packet;
+        this.reqHeaders = reqHeaders;
+        chunkSize = (Integer)context.invocationProperties.get(JAXWSProperties.HTTP_CLIENT_STREAMING_CHUNK_SIZE);
+    }
+
+    /*
+     * Prepare the stream for HTTP request
+     */
+    OutputStream getOutput() {
+        try {
+            createHttpConnection();
+            // for "GET" request no need to get outputStream
+            if (requiresOutputStream()) {
+                outputStream = httpConnection.getOutputStream();
+                if (chunkSize != null) {
+                    outputStream = new WSChunkedOuputStream(outputStream, chunkSize);
+                }
+                List<String> contentEncoding = reqHeaders.get("Content-Encoding");
+                // TODO need to find out correct encoding based on q value - RFC 2616
+                if (contentEncoding != null && contentEncoding.get(0).contains("gzip")) {
+                    outputStream = new GZIPOutputStream(outputStream);
+                }
+            }
+            httpConnection.connect();
+        } catch (Exception ex) {
+            throw new ClientTransportException(
+                ClientMessages.localizableHTTP_CLIENT_FAILED(ex),ex);
+        }
+
+        return outputStream;
+    }
+
+    void closeOutput() throws IOException {
+        if (outputStream != null) {
+            outputStream.close();
+            outputStream = null;
+        }
+    }
+
+    /*
+     * Get the response from HTTP connection and prepare the input stream for response
+     */
+    @Nullable InputStream getInput() {
+        // response processing
+
+        InputStream in;
+        try {
+            in = readResponse();
+            if (in != null) {
+                String contentEncoding = httpConnection.getContentEncoding();
+                if (contentEncoding != null && contentEncoding.contains("gzip")) {
+                    in = new GZIPInputStream(in);
+                }
+            }
+        } catch (IOException e) {
+            throw new ClientTransportException(ClientMessages.localizableHTTP_STATUS_CODE(statusCode, statusMessage), e);
+        }
+        return in;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        if (respHeaders != null) {
+            return respHeaders;
+        }
+        respHeaders = new Headers();
+        respHeaders.putAll(httpConnection.getHeaderFields());
+        return respHeaders;
+    }
+
+    protected @Nullable InputStream readResponse() {
+        InputStream is;
+        try {
+            is = httpConnection.getInputStream();
+        } catch(IOException ioe) {
+            is = httpConnection.getErrorStream();
+        }
+        if (is == null) {
+            return is;
+        }
+        // Since StreamMessage doesn't read </s:Body></s:Envelope>, there
+        // are some bytes left in the InputStream. This confuses JDK and may
+        // not reuse underlying sockets. Hopefully JDK fixes it in its code !
+        final InputStream temp = is;
+        return new FilterInputStream(temp) {
+            // Workaround for "SJSXP XMLStreamReader.next() closes stream".
+            // So it doesn't read from the closed stream
+            boolean closed;
+            @Override
+            public void close() throws IOException {                
+                if (!closed) {
+                    closed = true;
+                    while(temp.read(THROW_AWAY_BUFFER) != -1);
+                    super.close();
+                }
+            }
+        };
+    }
+
+    protected void readResponseCodeAndMessage() {
+        try {
+            statusCode = httpConnection.getResponseCode();
+            statusMessage = httpConnection.getResponseMessage();
+            contentLength = httpConnection.getContentLength();
+        } catch(IOException ioe) {
+            throw new WebServiceException(ioe);
+        }
+    }
+
+    protected HttpURLConnection openConnection(Packet packet) {
+    	// default do nothing
+    	return null;
+    }
+    
+    protected boolean checkHTTPS(HttpURLConnection connection) {
+        if (connection instanceof HttpsURLConnection) {
+
+            // TODO The above property needs to be removed in future version as the semantics of this property are not preoperly defined.
+            // One should use JAXWSProperties.HOSTNAME_VERIFIER to control the behavior
+
+            // does the client want client hostname verification by the service
+            String verificationProperty =
+                (String) context.invocationProperties.get(HOSTNAME_VERIFICATION_PROPERTY);
+            if (verificationProperty != null) {
+                if (verificationProperty.equalsIgnoreCase("true")) {
+                    ((HttpsURLConnection) connection).setHostnameVerifier(new HttpClientVerifier());
+                }
+            }
+
+            // Set application's HostNameVerifier for this connection
+            HostnameVerifier verifier =
+                (HostnameVerifier) context.invocationProperties.get(JAXWSProperties.HOSTNAME_VERIFIER);
+            if (verifier != null) {
+                ((HttpsURLConnection) connection).setHostnameVerifier(verifier);
+            }
+
+            // Set application's SocketFactory for this connection
+            SSLSocketFactory sslSocketFactory =
+                (SSLSocketFactory) context.invocationProperties.get(JAXWSProperties.SSL_SOCKET_FACTORY);
+            if (sslSocketFactory != null) {
+                ((HttpsURLConnection) connection).setSSLSocketFactory(sslSocketFactory);
+            }
+            
+            return true;
+        }
+        return false;
+    }
+    
+    private void createHttpConnection() throws IOException {
+    	httpConnection = openConnection(context);
+
+    	if (httpConnection == null)
+    		httpConnection = (HttpURLConnection) endpoint.openConnection();
+    	
+        String scheme = endpoint.getURI().getScheme();
+        if (scheme.equals("https")) {
+            https = true;
+        }
+        if (checkHTTPS(httpConnection))
+        	https = true;
+
+        // allow interaction with the web page - user may have to supply
+        // username, password id web page is accessed from web browser
+        httpConnection.setAllowUserInteraction(true);
+
+        // enable input, output streams
+        httpConnection.setDoOutput(true);
+        httpConnection.setDoInput(true);
+
+        String requestMethod = (String) context.invocationProperties.get(MessageContext.HTTP_REQUEST_METHOD);
+        String method = (requestMethod != null) ? requestMethod : "POST";
+        httpConnection.setRequestMethod(method);
+
+        //this code or something similiar needs t be moved elsewhere for error checking
+        /*if (context.invocationProperties.get(BindingProviderProperties.BINDING_ID_PROPERTY).equals(HTTPBinding.HTTP_BINDING)){
+            method = (requestMethod != null)?requestMethod:method;            
+        } else if
+            (context.invocationProperties.get(BindingProviderProperties.BINDING_ID_PROPERTY).equals(SOAPBinding.SOAP12HTTP_BINDING) &&
+            "GET".equalsIgnoreCase(requestMethod)) {
+        }
+       */     
+
+        Integer reqTimeout = (Integer)context.invocationProperties.get(BindingProviderProperties.REQUEST_TIMEOUT);
+        if (reqTimeout != null) {
+            httpConnection.setReadTimeout(reqTimeout);
+        }
+
+        Integer connectTimeout = (Integer)context.invocationProperties.get(JAXWSProperties.CONNECT_TIMEOUT);
+        if (connectTimeout != null) {
+            httpConnection.setConnectTimeout(connectTimeout);
+        }
+
+        Integer chunkSize = (Integer)context.invocationProperties.get(JAXWSProperties.HTTP_CLIENT_STREAMING_CHUNK_SIZE);
+        if (chunkSize != null) {
+            httpConnection.setChunkedStreamingMode(chunkSize);
+        }
+
+        Authenticator auth = (Authenticator)context.invocationProperties.get(JAXWSProperties.REQUEST_AUTHENTICATOR);
+        if (auth != null) {
+			httpConnection.setAuthenticator(auth);
+        }
+        
+        // set the properties on HttpURLConnection
+        for (Map.Entry<String, List<String>> entry : reqHeaders.entrySet()) {
+            if ("Content-Length".equals(entry.getKey())) continue;
+        	for(String value : entry.getValue()) {
+	            httpConnection.addRequestProperty(entry.getKey(), value);
+        	}
+        }
+    }
+
+    boolean isSecure() {
+        return https;
+    }
+    
+    protected void setStatusCode(int statusCode) {
+    	this.statusCode = statusCode;
+    }
+
+    private boolean requiresOutputStream() {
+        return !(httpConnection.getRequestMethod().equalsIgnoreCase("GET") ||
+                httpConnection.getRequestMethod().equalsIgnoreCase("HEAD") ||
+                httpConnection.getRequestMethod().equalsIgnoreCase("DELETE"));
+    }
+
+    @Nullable String getContentType() {
+        return httpConnection.getContentType();
+    }
+    
+    public int getContentLength() {
+    	return httpConnection.getContentLength();
+    }
+
+    // overide default SSL HttpClientVerifier to always return true
+    // effectively overiding Hostname client verification when using SSL
+    private static class HttpClientVerifier implements HostnameVerifier {
+        public boolean verify(String s, SSLSession sslSession) {
+            return true;
+        }
+    }
+
+    private static class LocalhostHttpClientVerifier implements HostnameVerifier {
+        public boolean verify(String s, SSLSession sslSession) {
+            return "localhost".equalsIgnoreCase(s) || "127.0.0.1".equals(s);
+        }
+    }
+
+    /**
+     * HttpURLConnection.getOuputStream() returns sun.net.www.http.ChunkedOuputStream in chunked
+     * streaming mode. If you call ChunkedOuputStream.write(byte[20MB], int, int), then the whole data
+     * is kept in memory. This wraps the ChunkedOuputStream so that it writes only small
+     * chunks.
+     */
+    private static final class WSChunkedOuputStream extends FilterOutputStream {
+        final int chunkSize;
+
+        WSChunkedOuputStream(OutputStream actual, int chunkSize) {
+            super(actual);
+            this.chunkSize = chunkSize;
+        }
+
+        @Override
+        public void write(byte b[], int off, int len) throws IOException {
+            while(len > 0) {
+                int sent = (len > chunkSize) ? chunkSize : len;
+                out.write(b, off, sent);        // don't use super.write() as it writes byte-by-byte
+                len -= sent;
+                off += sent;
+            }
+        }
+
+    }
+
+}
+

--- a/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/transport/http/developer/JAXWSProperties.java
+++ b/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/transport/http/developer/JAXWSProperties.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.developer;
+
+import com.sun.xml.ws.api.message.HeaderList;
+import com.sun.xml.ws.api.server.WSEndpoint;
+import com.sun.xml.ws.api.addressing.WSEndpointReference;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.WebServiceContext;
+import javax.xml.ws.BindingType;
+import javax.xml.ws.http.HTTPBinding;
+import java.net.HttpURLConnection;
+
+public interface JAXWSProperties {
+    // Content negotiation property: values "none", "pessimistic" and "optimistic"
+    // It is split into two strings so that package renaming for
+    // Java SE 6 doesn't alter the value. So do not combine them
+    @Deprecated
+    public static final String CONTENT_NEGOTIATION_PROPERTY = "com.sun."+"xml.ws.client.ContentNegotiation";
+    public static final String MTOM_THRESHOLOD_VALUE =  "com.sun.xml.ws.common.MtomThresholdValue";
+    public static final String HTTP_EXCHANGE = "com.sun.xml.ws.http.exchange";
+
+    /**
+     * Set this property on the {@link BindingProvider#getRequestContext()} to
+     * enable {@link HttpURLConnection#setConnectTimeout(int)}
+     *
+     *<p>
+     * int timeout = ...;
+     * Map<String, Object> ctxt = ((BindingProvider)proxy).getRequestContext();
+     * ctxt.put(CONNECT_TIMEOUT, timeout);
+     */
+    public static final String CONNECT_TIMEOUT =
+        "com.sun.xml.ws.connect.timeout";
+
+    /**
+     * Set this property on the {@link BindingProvider#getRequestContext()} to
+     * enable {@link HttpURLConnection#setReadTimeout(int)}
+     *
+     *<p>
+     * int timeout = ...;
+     * Map<String, Object> ctxt = ((BindingProvider)proxy).getRequestContext();
+     * ctxt.put(REQUEST_TIMEOUT, timeout);
+     */
+     public static final String REQUEST_TIMEOUT =
+        "com.sun.xml.ws.request.timeout";
+
+    /**
+     * Set this property on the {@link BindingProvider#getRequestContext()} to
+     * enable {@link HttpURLConnection#setChunkedStreamingMode(int)}
+     *
+     *<p>
+     * int chunkSize = ...;
+     * Map<String, Object> ctxt = ((BindingProvider)proxy).getRequestContext();
+     * ctxt.put(HTTP_CLIENT_STREAMING_CHUNK_SIZE, chunkSize);
+     */
+    public static final String HTTP_CLIENT_STREAMING_CHUNK_SIZE = "com.sun.xml.ws.transport.http.client.streaming.chunk.size";
+
+
+    /**
+     * Set this property on the {@link BindingProvider#getRequestContext()} to
+     * enable {@link HttpsURLConnection#setHostnameVerifier(HostnameVerifier)}}. The property
+     * is set as follows:
+     *
+     * <p>
+     * HostNameVerifier hostNameVerifier = ...;
+     * Map<String, Object> ctxt = ((BindingProvider)proxy).getRequestContext();
+     * ctxt.put(HOSTNAME_VERIFIER, hostNameVerifier);
+     *
+     * <p>
+     * <b>THIS PROPERTY IS EXPERIMENTAL AND IS SUBJECT TO CHANGE WITHOUT NOTICE IN FUTURE.</b>
+     */
+    public static final String HOSTNAME_VERIFIER = "com.sun.xml.ws.transport.https.client.hostname.verifier";
+
+    /**
+     * Set this property on the {@link BindingProvider#getRequestContext()} to
+     * enable {@link HttpsURLConnection#setSSLSocketFactory(SSLSocketFactory)}. The property is set
+     * as follows:
+     *
+     * <p>
+     * SSLSocketFactory sslFactory = ...;
+     * Map<String, Object> ctxt = ((BindingProvider)proxy).getRequestContext();
+     * ctxt.put(SSL_SOCKET_FACTORY, sslFactory);
+     *
+     * <p>
+     * <b>THIS PROPERTY IS EXPERIMENTAL AND IS SUBJECT TO CHANGE WITHOUT NOTICE IN FUTURE.</b>
+     */
+    public static final String SSL_SOCKET_FACTORY = "com.sun.xml.ws.transport.https.client.SSLSocketFactory";
+
+    /**
+     * Acccess the list of SOAP headers in the SOAP message.
+     *
+     * <p>
+     * On {@link WebServiceContext}, this property returns a {@link HeaderList} object
+     * that represents SOAP headers in the request message that was received.
+     * On {@link BindingProvider#getResponseContext()}, this property returns a
+     * {@link HeaderList} object that represents SOAP headers in the response message from the server.
+     *
+     * <p>
+     * The property is read-only, and please do not modify the returned {@link HeaderList}
+     * as that may break the JAX-WS RI in some unexpected way.
+     *
+     * <p>
+     * <b>THIS PROPERTY IS EXPERIMENTAL AND IS SUBJECT TO CHANGE WITHOUT NOTICE IN FUTURE.</b>
+     */
+    public static final String INBOUND_HEADER_LIST_PROPERTY = "com.sun.xml.ws.api.message.HeaderList";
+
+    /**
+     * Access the {@link WSEndpoint} object that delivered the request.
+     *
+     * <p>
+     * {@link WSEndpoint} is the root of the objects that are together
+     * responsible for delivering requests to the application SEI object.
+     * One can look up this {@link WSEndpoint} from {@link WebServiceContext},
+     * and from there access many parts of the JAX-WS RI runtime.
+     *
+     * <p>
+     * <b>THIS PROPERTY IS EXPERIMENTAL AND IS SUBJECT TO CHANGE WITHOUT NOTICE IN FUTURE.</b>
+     *
+     * @since 2.1.2
+     */
+    public static final String WSENDPOINT = "com.sun.xml.ws.api.server.WSEndpoint";
+
+    /**
+     * Gets the {@code wsa:To} header.
+     *
+     * The propery value is available on incoming SOAP message. The type of the value
+     * is {@link WSEndpointReference}.
+     * 
+     * Null if the incoming SOAP message didn't have the header.
+     *
+     * @since 2.1.3
+     */
+    public static final String ADDRESSING_TO = "com.sun.xml.ws.api.addressing.to";
+
+    /**
+     * Gets the {@code wsa:From} header.
+     *
+     * The propery value is available on incoming SOAP message. The type of the value
+     * is {@link WSEndpointReference}.
+     *
+     * Null if the incoming SOAP message didn't have the header.
+     *
+     * @since 2.1.3
+     */
+    public static final String ADDRESSING_FROM = "com.sun.xml.ws.api.addressing.from";
+
+    /**
+     * Gets the {@code wsa:Action} header value.
+     *
+     * The propery value is available on incoming SOAP message. The type of the value
+     * is {@link String}.
+     *
+     * Null if the incoming SOAP message didn't have the header.
+     *
+     * @since 2.1.3
+     */
+    public static final String ADDRESSING_ACTION = "com.sun.xml.ws.api.addressing.action";
+
+    /**
+     * Gets the {@code wsa:MessageID} header value.
+     *
+     * The propery value is available on incoming SOAP message. The type of the value
+     * is {@link String}.
+     *
+     * Null if the incoming SOAP message didn't have the header.
+     *
+     * @since 2.1.3
+     */
+    public static final String ADDRESSING_MESSAGEID = "com.sun.xml.ws.api.addressing.messageId";
+
+    /**
+     * Reconstructs the URL the client used to make the request. The returned URL
+     * contains a protocol, server name, port number, and server path, but it does
+     * not include query string parameters.
+     * <p>
+     * The property value is available on incoming SOAP message on servlet transport.
+     *
+     * @since 2.1.3
+     */
+    public static final String HTTP_REQUEST_URL = "com.sun.xml.ws.transport.http.servlet.requestURL";
+
+    /**
+     * Binding to represent RESTful services. {@link HTTPBinding#HTTP_BINDING} works
+     * only for Dispatch/Provider services, but this binding works with even SEI based
+     * services. It would be XML, NOT SOAP on the wire. Hence, the SEI parameters
+     * shouldn't be mapped to headers.
+     *
+     * <p>
+     * Note that, this only solves limited RESTful usecases.
+     *
+     * <p>To enable restful binding on the service, specify the binding id via
+     * {@link BindingType} or DD
+     * <pre>
+     * &#64;WebService
+     * &#64;BindingType(JAXWSProperties.REST_BINDING)
+     * </pre>
+     *
+     * <p>To enable restful binding on the client side, specify the binding id via
+     * {@link BindingTypeFeature}
+     * <pre>
+     * proxy = echoImplService.getEchoImplPort(new BindingTypeFeature(JAXWSProperties.REST_BINDING));
+     * </pre>
+     *
+     * @since 2.1.4
+     */
+    public static final String REST_BINDING = "http://jax-ws.dev.java.net/rest";
+    
+    public static final String REQUEST_AUTHENTICATOR = 
+    		"com.sun.xml.ws.request.authenticator";
+
+    
+}


### PR DESCRIPTION
For Java 9+, HttpURLConnection allows the client to set a non-default Authenticator using setAuthenticator(). Added the ability for clients to set the value when using this library. This will allow clients to avoid the cached credentials bug described here: https://bugs.openjdk.java.net/browse/JDK-4303463