### PR TITLE
Expose setAuthenticator method of HttpURLConnection for Java 9+

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/util/AuthUtil.java
+++ b/jaxws-ri/runtime/rt/src/main/java-mr/9/com/sun/xml/ws/util/AuthUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package com.sun.xml.ws.util;
+
+import java.net.HttpURLConnection;
+import java.net.Authenticator;
+
+/**
+ * Utils for HttpURLConnection authentication.
+ * 
+ * Version for {@code runtime >= 9}.
+ * 
+ * @author Nancy Bosecker
+ *
+ */
+public class AuthUtil {
+	
+	/**
+	 * Sets the authenticator on the {@link HttpURLConnection} by invoking {@link HttpURLConnection#setAuthenticator(Authenticator)}.
+	 * 
+	 * Version for {@code runtime >= 9}.
+	 */
+	public static void setAuthenticator(Authenticator authenticator, HttpURLConnection httpConnection) {
+		httpConnection.setAuthenticator(authenticator);
+	}
+}

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/developer/JAXWSProperties.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/developer/JAXWSProperties.java
@@ -217,4 +217,13 @@ public interface JAXWSProperties {
      */
     public static final String REST_BINDING = "http://jax-ws.dev.java.net/rest";
     
+	/**
+	 * Set this property to enable {@link HttpURLConnection#setAuthenticator(Authenticator)}, 
+	 * available in JDK9+.
+	 *
+	 * @since 2.3.4
+	 */
+    public static final String REQUEST_AUTHENTICATOR = "com.sun.xml.ws.request.authenticator";
+
+    
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/transport/http/client/HttpClientTransport.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/transport/http/client/HttpClientTransport.java
@@ -18,6 +18,7 @@ import com.sun.xml.ws.client.ClientTransportException;
 import com.sun.xml.ws.resources.ClientMessages;
 import com.sun.xml.ws.transport.Headers;
 import com.sun.xml.ws.developer.JAXWSProperties;
+import com.sun.xml.ws.util.AuthUtil;
 import com.sun.istack.Nullable;
 import com.sun.istack.NotNull;
 
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.GZIPInputStream;
+import java.net.Authenticator;
 
 /**
  *
@@ -267,6 +269,11 @@ public class HttpClientTransport {
         Integer chunkSize = (Integer)context.invocationProperties.get(JAXWSProperties.HTTP_CLIENT_STREAMING_CHUNK_SIZE);
         if (chunkSize != null) {
             httpConnection.setChunkedStreamingMode(chunkSize);
+        }
+
+        Authenticator auth = (Authenticator)context.invocationProperties.get(JAXWSProperties.REQUEST_AUTHENTICATOR);
+        if ( auth != null ) {
+            AuthUtil.setAuthenticator(auth, httpConnection);
         }
 
         // set the properties on HttpURLConnection

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/util/AuthUtil.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/util/AuthUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package com.sun.xml.ws.util;
+
+import java.net.HttpURLConnection;
+import java.net.Authenticator;
+
+/**
+ * Utils for HttpURLConnection authentication.
+ * 
+ *  Version for {@code runtime < 9}.
+ * 
+ * @author Nancy Bosecker
+ *
+ */
+public class AuthUtil {
+	
+	/**
+	 * No-op for {@code runtime < 9}.
+	 */
+	public static void setAuthenticator(Authenticator authenticator, HttpURLConnection httpConnection) {
+	}
+}


### PR DESCRIPTION
Author: Nancy Bosecker <nbosecker@gmail.com>
Date: Fri Sept 18 16:24:00 2020

For Java 9+, allow clients to set an authenticator on HttpURLConnection class, which allows clients to avoid use of the default Authenticator whose cache is hidden and cannot be cleared. See https://bugs.openjdk.java.net/browse/JDK-8169495

Signed-off-by: Nancy Bosecker <nbosecker@gmail.com>