### PR TITLE
#582: JAX-WS write Content-ID: header with small 'd' letter and without a space after ':' for MIME Attachment part

### DIFF
--- a/jaxws-ri/docs/release-documentation/src/main/docbook/changelog.xml
+++ b/jaxws-ri/docs/release-documentation/src/main/docbook/changelog.xml
@@ -51,6 +51,9 @@
                     <link xlink:href="https://github.com/eclipse-ee4j/metro-jax-ws/issues/336">#336</link>: wsimport: -target option does not generate old javax.xml.ws package name
                 </para></listitem>
                 <listitem><para>
+                    <link xlink:href="https://github.com/eclipse-ee4j/metro-jax-ws/issues/582">#582</link>: Use 'Content-ID: ' header instead of ' Content-Id:'
+                </para></listitem>
+                <listitem><para>
                     <link xlink:href="https://github.com/eclipse-ee4j/metro-jax-ws/issues/597">#597</link>: impossible cast in spi/db/TypeInfo
                 </para></listitem>
             </itemizedlist>

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/MimeCodec.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/MimeCodec.java
@@ -99,7 +99,7 @@ public abstract class MimeCodec implements Codec {
                 String cid = att.getContentId();
                 if(cid != null && cid.length() >0 && cid.charAt(0) != '<')
                     cid = '<' + cid + '>';
-                writeln("Content-Id:" + cid, out);
+                writeln("Content-ID: " + cid, out);
                 writeln("Content-Type: " + att.getContentType(), out);
                 writeCustomMimeHeaders(att, out);
                 writeln("Content-Transfer-Encoding: binary", out);
@@ -121,7 +121,7 @@ public abstract class MimeCodec implements Codec {
                 AttachmentEx.MimeHeader mh = allMimeHeaders.next();
                 String name = mh.getName();
 
-                if (!"Content-Type".equalsIgnoreCase(name) && !"Content-Id".equalsIgnoreCase(name)) {
+                if (!"Content-Type".equalsIgnoreCase(name) && !"Content-ID".equalsIgnoreCase(name)) {
                     writeln(name +": " + mh.getValue(), out);
                 }
             }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/MtomCodec.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/MtomCodec.java
@@ -221,7 +221,7 @@ public class MtomCodec extends MimeCodec {
         String cid = contentId;
         if(cid != null && cid.length() >0 && cid.charAt(0) != '<')
             cid = '<' + cid + '>';
-        writeln("Content-Id: " + cid, out);
+        writeln("Content-ID: " + cid, out);
         writeln("Content-Type: " + contentType, out);
         writeln("Content-Transfer-Encoding: binary", out);
         writeln(out);

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/message/saaj/SAAJMessage.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/message/saaj/SAAJMessage.java
@@ -284,7 +284,7 @@ public class SAAJMessage extends Message {
                 AttachmentEx.MimeHeader mh = allMimeHeaders.next();
                 String name = mh.getName();
                 if (!"Content-Type".equalsIgnoreCase(name)
-                        && !"Content-Id".equalsIgnoreCase(name)) {
+                        && !"Content-ID".equalsIgnoreCase(name)) {
                     part.addMimeHeader(name, mh.getValue());
                 }
             }


### PR DESCRIPTION
fixes #582 