### PR TITLE
Bugno34600318

### DIFF
--- a/jaxws-ri/docs/release-documentation/src/main/docbook/changelog.xml
+++ b/jaxws-ri/docs/release-documentation/src/main/docbook/changelog.xml
@@ -32,6 +32,9 @@
                 <listitem>
                     <para>Switches protocol for W3C schemas to https, see <link xlink:href="https://www.w3.org/blog/2022/07/redirecting-to-https-on-www-w3-org/">the announcement</link> for details</para>
                 </listitem>
+                    <para>Added a new system property named com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage, which when set to false will not add exception messages in the faultstring</para>
+                <listitem>
+                </listitem>
             </itemizedlist>
         </listitem>
 

--- a/jaxws-ri/docs/release-documentation/src/main/docbook/jax-ws-ri-extensions.xml
+++ b/jaxws-ri/docs/release-documentation/src/main/docbook/jax-ws-ri-extensions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -125,6 +125,29 @@ bp.setOutboundHeaders(
 
             <informalexample>
                 <programlisting><![CDATA[com.sun.xml.ws.fault.SOAPFaultBuilder.captureStackTrace=true]]></programlisting>
+            </informalexample>
+        </section>
+    </section>
+
+    <section xml:id="capture-of-exception-message-in-faultstring">
+        <title>Capture of exception message in faultstring</title>
+
+        <para>The soap fault messages has a faultstring which contains
+        the exception message if any received from the server side.
+        If the customer does not want to display any exception messages
+        from the server side then this system property can be used to
+        disable that.</para>
+
+        <section xml:id="disabling-capture-of-exception-message-in-faultstring">
+            <title>Disabling capture of exception message in faultstring</title>
+
+            <para>The capture of exception message in faultstring is enabled
+            by default. For your Web Service Application to disable the capture
+            of exception message in faultstring, set the system property to
+            false</para>
+
+            <informalexample>
+                <programlisting><![CDATA[com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage=false]]></programlisting>
             </informalexample>
         </section>
     </section>

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -379,7 +379,7 @@ public abstract class SOAPFaultBuilder {
         }
 
         if (faultString == null) {
-            if (Boolean.getBoolean("com.sun.xml.ws.fault.doNotPrintExpMsg")) {
+            if (!getCaptureExceptionMessage()) {
                 faultString = "Server Error";
             }
             else {
@@ -538,6 +538,7 @@ public abstract class SOAPFaultBuilder {
 
     private static final Logger logger = Logger.getLogger(SOAPFaultBuilder.class.getName());
 
+    private static boolean captureExceptionMessage = getBooleanSystemProperty();
     /**
      * Set to false if you don't want the generated faults to have stack trace in it.
      */
@@ -563,4 +564,22 @@ public abstract class SOAPFaultBuilder {
             throw new Error(e);
         }
     }
+
+   private static boolean getBooleanSystemProperty() {
+        final String propertyString = System.getProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage");
+        if (propertyString == null) {
+            //default value 
+            return true;
+        } else {
+            return Boolean.getBoolean(propertyString);
+        }
+    }
+
+   public static boolean getCaptureExceptionMessage() {
+        return captureExceptionMessage;
+   }
+
+   public static void setCaptureExceptionMessage() {
+        captureExceptionMessage = getBooleanSystemProperty();
+   }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -379,7 +379,7 @@ public abstract class SOAPFaultBuilder {
         }
 
         if (faultString == null) {
-            if (!getCaptureExceptionMessage()) {
+            if (!isCaptureExceptionMessage()) {
                 faultString = "Server Error";
             }
             else {
@@ -538,13 +538,17 @@ public abstract class SOAPFaultBuilder {
 
     private static final Logger logger = Logger.getLogger(SOAPFaultBuilder.class.getName());
 
-    private static boolean captureExceptionMessage = getBooleanSystemProperty();
+    private static boolean captureExceptionMessage = true;
     /**
      * Set to false if you don't want the generated faults to have stack trace in it.
      */
     public static final boolean captureStackTrace;
 
     /*package*/ static final String CAPTURE_STACK_TRACE_PROPERTY = SOAPFaultBuilder.class.getName()+".captureStackTrace";
+
+   public static void setCaptureExceptionMessage(boolean capture) {
+        captureExceptionMessage = capture;
+   }
 
     static {
         boolean tmpVal = false;
@@ -555,6 +559,13 @@ public abstract class SOAPFaultBuilder {
         }
         captureStackTrace = tmpVal;
         JAXB_CONTEXT = createJAXBContext();
+        try {
+            if (System.getProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage") != null) {
+                setCaptureExceptionMessage(Boolean.getBoolean("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage"));
+            }
+        } catch (SecurityException e) {
+            // ignore
+        }
     }
 
     private static JAXBContext createJAXBContext() {
@@ -565,21 +576,7 @@ public abstract class SOAPFaultBuilder {
         }
     }
 
-   private static boolean getBooleanSystemProperty() {
-        final String propertyString = System.getProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage");
-        if (propertyString == null) {
-            //default value 
-            return true;
-        } else {
-            return Boolean.getBoolean(propertyString);
-        }
-    }
-
-   public static boolean getCaptureExceptionMessage() {
+   public static boolean isCaptureExceptionMessage() {
         return captureExceptionMessage;
-   }
-
-   public static void setCaptureExceptionMessage() {
-        captureExceptionMessage = getBooleanSystemProperty();
    }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -379,9 +379,14 @@ public abstract class SOAPFaultBuilder {
         }
 
         if (faultString == null) {
-            faultString = e.getMessage();
-            if (faultString == null) {
-                faultString = e.toString();
+            if (Boolean.getBoolean("com.sun.xml.ws.fault.doNotPrintExpMsg")) {
+                faultString = "Server Error";
+            }
+            else {
+                faultString = e.getMessage();
+                if (faultString == null) {
+                    faultString = e.toString();
+                }
             }
         }
         Element detailNode = null;

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -122,11 +122,9 @@ public class SOAPFaultBuilderTest extends TestCase {
     }
 
     public void testCreate11FaultFromRE() {
-        Properties props = System.getProperties();
-        props.setProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage","false");
         RuntimeException re =  new RuntimeException("XML reader error: com.ctc.wstx.exc.WstxParsingException: Unexpected < character in element");
         try {
-            SOAPFaultBuilder.setCaptureExceptionMessage();
+            SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_11, null, re);
             XMLStreamReader rdr = faultMsg.readPayload();
             while(rdr.hasNext()) {
@@ -141,8 +139,6 @@ public class SOAPFaultBuilderTest extends TestCase {
         } catch(Exception ex) {
              ex.printStackTrace();
              fail(ex.getMessage());
-        } finally {
-             System.clearProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage");
         }
     }
 

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -33,7 +33,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import jakarta.xml.ws.soap.SOAPFaultException;
 import java.io.StringWriter;
-import java.util.Properties;
 
 /**
  * @author Jitendra Kotamraju

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -123,9 +123,10 @@ public class SOAPFaultBuilderTest extends TestCase {
 
     public void testCreate11FaultFromRE() {
         Properties props = System.getProperties();
-        props.setProperty("com.sun.xml.ws.fault.doNotPrintExpMsg","true");
+        props.setProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage","false");
         RuntimeException re =  new RuntimeException("XML reader error: com.ctc.wstx.exc.WstxParsingException: Unexpected < character in element");
         try {
+            SOAPFaultBuilder.setCaptureExceptionMessage();
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_11, null, re);
             XMLStreamReader rdr = faultMsg.readPayload();
             while(rdr.hasNext()) {
@@ -141,7 +142,7 @@ public class SOAPFaultBuilderTest extends TestCase {
              ex.printStackTrace();
              fail(ex.getMessage());
         } finally {
-             System.clearProperty("com.sun.xml.ws.fault.doNotPrintExpMsg");
+             System.clearProperty("com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage");
         }
     }
 

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -138,6 +138,8 @@ public class SOAPFaultBuilderTest extends TestCase {
         } catch(Exception ex) {
              ex.printStackTrace();
              fail(ex.getMessage());
+        } finally{
+             SOAPFaultBuilder.setCaptureExceptionMessage(true);
         }
     }
 


### PR DESCRIPTION
The faultstring in the SOAPFault contains the exception message if any which is the default current behavior

The customer has a requirement where they do not want any exception messages to be displayed in the faultstring for security concerns of exposing class

Therefore, we are adding a new system property -Dcom.sun.xml.ws.fault.doNotPrintExpMsg=true
to implement the behavior requested by the customer

Added testcase at 
./jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java