### PR TITLE
BUG 35047999: Show Server Error in faultString instead of error details.

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP11Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP11Fault.java
@@ -76,7 +76,7 @@ class SOAP11Fault extends SOAPFaultBuilder {
      */
     SOAP11Fault(QName code, String reason, String actor, Element detailObject) {
         this.faultcode = code;
-        this.faultstring = changeFaultStringToServerError(reason);
+        this.faultstring = createFaultString(reason);
         this.faultactor = actor;
         if (detailObject != null) {
             if ((detailObject.getNamespaceURI() == null ||
@@ -93,7 +93,7 @@ class SOAP11Fault extends SOAPFaultBuilder {
 
     SOAP11Fault(SOAPFault fault) {
         this.faultcode = fault.getFaultCodeAsQName();
-        this.faultstring = changeFaultStringToServerError(fault.getFaultString());
+        this.faultstring = createFaultString(fault.getFaultString());
         this.faultactor = fault.getFaultActor();
         if (fault.getDetail() != null) {
             detail = new DetailType();

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP11Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP11Fault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -76,7 +76,7 @@ class SOAP11Fault extends SOAPFaultBuilder {
      */
     SOAP11Fault(QName code, String reason, String actor, Element detailObject) {
         this.faultcode = code;
-        this.faultstring = reason;
+        this.faultstring = changeFaultStringToServerError(reason);
         this.faultactor = actor;
         if (detailObject != null) {
             if ((detailObject.getNamespaceURI() == null ||
@@ -93,7 +93,7 @@ class SOAP11Fault extends SOAPFaultBuilder {
 
     SOAP11Fault(SOAPFault fault) {
         this.faultcode = fault.getFaultCodeAsQName();
-        this.faultstring = fault.getFaultString();
+        this.faultstring = changeFaultStringToServerError(fault.getFaultString());
         this.faultactor = fault.getFaultActor();
         if (fault.getDetail() != null) {
             detail = new DetailType();

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -99,7 +99,7 @@ class SOAP12Fault extends SOAPFaultBuilder {
 
     SOAP12Fault(CodeType code, ReasonType reason, String node, String role, Element detailObject) {
         this.code = code;
-        this.reason = reason;
+        this.reason = isCaptureExceptionMessage() ? reason : new ReasonType(SERVER_ERROR);
         this.node = node;
         this.role = role;
         if (detailObject != null) {
@@ -122,7 +122,7 @@ class SOAP12Fault extends SOAPFaultBuilder {
             throw new WebServiceException(e);
         }
 
-        reason = new ReasonType(fault.getFaultString());
+        reason = new ReasonType(changeFaultStringToServerError(fault.getFaultString()));
         role = fault.getFaultRole();
         node = fault.getFaultNode();
         if (fault.getDetail() != null) {

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
@@ -122,7 +122,7 @@ class SOAP12Fault extends SOAPFaultBuilder {
             throw new WebServiceException(e);
         }
 
-        reason = new ReasonType(changeFaultStringToServerError(fault.getFaultString()));
+        reason = new ReasonType(createFaultString(fault.getFaultString()));
         role = fault.getFaultRole();
         node = fault.getFaultNode();
         if (fault.getDetail() != null) {

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
@@ -99,7 +99,7 @@ class SOAP12Fault extends SOAPFaultBuilder {
 
     SOAP12Fault(CodeType code, ReasonType reason, String node, String role, Element detailObject) {
         this.code = code;
-        this.reason = isCaptureExceptionMessage() ? reason : new ReasonType(SERVER_ERROR);
+        this.reason = isCaptureExceptionMessage() ? reason : new ReasonType(getConstantServerError());
         this.node = node;
         this.role = role;
         if (detailObject != null) {

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAP12Fault.java
@@ -99,7 +99,7 @@ class SOAP12Fault extends SOAPFaultBuilder {
 
     SOAP12Fault(CodeType code, ReasonType reason, String node, String role, Element detailObject) {
         this.code = code;
-        this.reason = isCaptureExceptionMessage() ? reason : new ReasonType(getConstantServerError());
+        this.reason = isCaptureExceptionMessage() ? reason : new ReasonType(createFaultString());
         this.node = node;
         this.role = role;
         if (detailObject != null) {

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
  */
 public abstract class SOAPFaultBuilder {
 
-    protected static final String SERVER_ERROR = "Server Error";
+    private static final String SERVER_ERROR = "Server Error";
 
     /**
      * Default constructor.
@@ -583,5 +583,9 @@ public abstract class SOAPFaultBuilder {
 
     protected static String createFaultString(String faultString) {
         return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
+    }
+
+    protected static String getConstantServerError(){
+       return SERVER_ERROR;
     }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
  */
 public abstract class SOAPFaultBuilder {
 
-    public static final String SERVER_ERROR = "Server Error";
+    private static final String SERVER_ERROR = "Server Error";
 
     /**
      * Default constructor.
@@ -233,9 +233,7 @@ public abstract class SOAPFaultBuilder {
     }
 
     private static Message createSOAPFaultMessage(SOAPVersion soapVersion, String faultString, QName faultCode, Element detail) {
-        if (!isCaptureExceptionMessage()) {
-            faultString = SERVER_ERROR;
-        }
+        faultString = setFaultStringToServerError(faultString);
         switch (soapVersion) {
             case SOAP_11:
                 return JAXBMessage.create(JAXB_CONTEXT, new SOAP11Fault(faultCode, faultString, null, detail), soapVersion);
@@ -412,9 +410,7 @@ public abstract class SOAPFaultBuilder {
             }
         }
 
-        if (!isCaptureExceptionMessage()) {
-            faultString = SERVER_ERROR;
-        }
+        faultString = setFaultStringToServerError(faultString);
 
         SOAP11Fault soap11Fault = new SOAP11Fault(faultCode, faultString, faultActor, detailNode);
         
@@ -510,9 +506,7 @@ public abstract class SOAPFaultBuilder {
             }
         }
 
-        if (!isCaptureExceptionMessage()) {
-            faultString = SERVER_ERROR;
-        }
+        faultString = setFaultStringToServerError(faultString);
         ReasonType reason = new ReasonType(faultString);
 
         SOAP12Fault soap12Fault = new SOAP12Fault(code, reason, faultNode, faultRole, detailNode);
@@ -593,4 +587,9 @@ public abstract class SOAPFaultBuilder {
    public static boolean isCaptureExceptionMessage() {
         return captureExceptionMessage;
    }
+
+
+    private static String setFaultStringToServerError(String faultString) {
+        return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
+    }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -233,7 +233,7 @@ public abstract class SOAPFaultBuilder {
     }
 
     private static Message createSOAPFaultMessage(SOAPVersion soapVersion, String faultString, QName faultCode, Element detail) {
-        faultString = setFaultStringToServerError(faultString);
+        faultString = changeFaultStringToServerError(faultString);
         switch (soapVersion) {
             case SOAP_11:
                 return JAXBMessage.create(JAXB_CONTEXT, new SOAP11Fault(faultCode, faultString, null, detail), soapVersion);
@@ -410,7 +410,7 @@ public abstract class SOAPFaultBuilder {
             }
         }
 
-        faultString = setFaultStringToServerError(faultString);
+        faultString = changeFaultStringToServerError(faultString);
 
         SOAP11Fault soap11Fault = new SOAP11Fault(faultCode, faultString, faultActor, detailNode);
         
@@ -506,7 +506,7 @@ public abstract class SOAPFaultBuilder {
             }
         }
 
-        faultString = setFaultStringToServerError(faultString);
+        faultString = changeFaultStringToServerError(faultString);
         ReasonType reason = new ReasonType(faultString);
 
         SOAP12Fault soap12Fault = new SOAP12Fault(code, reason, faultNode, faultRole, detailNode);
@@ -589,7 +589,7 @@ public abstract class SOAPFaultBuilder {
    }
 
 
-    private static String setFaultStringToServerError(String faultString) {
+    private static String changeFaultStringToServerError(String faultString) {
         return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
     }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
  */
 public abstract class SOAPFaultBuilder {
 
-    private static final String SERVER_ERROR = "Server Error";
+    protected static final String SERVER_ERROR = "Server Error";
 
     /**
      * Default constructor.
@@ -218,10 +218,7 @@ public abstract class SOAPFaultBuilder {
         return createSOAPFaultMessage(soapVersion, faultString, faultCode, null);
     }
 
-    public static Message createSOAPFaultMessage(SOAPVersion soapVersion, SOAPFault fault) throws SOAPException {
-        if (!isCaptureExceptionMessage()) {
-            fault.setFaultString(SERVER_ERROR);
-        }
+    public static Message createSOAPFaultMessage(SOAPVersion soapVersion, SOAPFault fault) {
         switch (soapVersion) {
             case SOAP_11:
                 return JAXBMessage.create(JAXB_CONTEXT, new SOAP11Fault(fault), soapVersion);
@@ -233,7 +230,6 @@ public abstract class SOAPFaultBuilder {
     }
 
     private static Message createSOAPFaultMessage(SOAPVersion soapVersion, String faultString, QName faultCode, Element detail) {
-        faultString = changeFaultStringToServerError(faultString);
         switch (soapVersion) {
             case SOAP_11:
                 return JAXBMessage.create(JAXB_CONTEXT, new SOAP11Fault(faultCode, faultString, null, detail), soapVersion);
@@ -409,9 +405,6 @@ public abstract class SOAPFaultBuilder {
                 faultCode = getDefaultFaultCode(soapVersion);
             }
         }
-
-        faultString = changeFaultStringToServerError(faultString);
-
         SOAP11Fault soap11Fault = new SOAP11Fault(faultCode, faultString, faultActor, detailNode);
         
         //Don't fill the stacktrace for Service specific exceptions.
@@ -506,7 +499,6 @@ public abstract class SOAPFaultBuilder {
             }
         }
 
-        faultString = changeFaultStringToServerError(faultString);
         ReasonType reason = new ReasonType(faultString);
 
         SOAP12Fault soap12Fault = new SOAP12Fault(code, reason, faultNode, faultRole, detailNode);
@@ -589,7 +581,7 @@ public abstract class SOAPFaultBuilder {
    }
 
 
-    private static String changeFaultStringToServerError(String faultString) {
+    protected static String changeFaultStringToServerError(String faultString) {
         return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
     }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -581,7 +581,7 @@ public abstract class SOAPFaultBuilder {
    }
 
 
-    protected static String changeFaultStringToServerError(String faultString) {
+    protected static String createFaultString(String faultString) {
         return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
     }
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/fault/SOAPFaultBuilder.java
@@ -585,7 +585,7 @@ public abstract class SOAPFaultBuilder {
         return isCaptureExceptionMessage() ? faultString : SERVER_ERROR;
     }
 
-    protected static String getConstantServerError(){
+    protected static String createFaultString(){
        return SERVER_ERROR;
     }
 }

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -64,7 +64,6 @@ public class SOAPFaultBuilderTest extends TestCase {
     static {
         SOAPFault fault11 = null;
         SOAPFault fault12 = null;
-        SOAPFaultBuilder.setCaptureExceptionMessage(true);
         try {
             fault11 = createFault(SOAPVersion.SOAP_11);
             fault12 = createFault(SOAPVersion.SOAP_12);

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -64,6 +64,7 @@ public class SOAPFaultBuilderTest extends TestCase {
     static {
         SOAPFault fault11 = null;
         SOAPFault fault12 = null;
+        SOAPFaultBuilder.setCaptureExceptionMessage(true);
         try {
             fault11 = createFault(SOAPVersion.SOAP_11);
             fault12 = createFault(SOAPVersion.SOAP_12);
@@ -124,6 +125,7 @@ public class SOAPFaultBuilderTest extends TestCase {
 
     public void testCreate11FaultFromRE() {
         RuntimeException re =  new RuntimeException("XML reader error: com.ctc.wstx.exc.WstxParsingException: Unexpected < character in element");
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_11, null, re);
@@ -132,13 +134,15 @@ public class SOAPFaultBuilderTest extends TestCase {
              ex.printStackTrace();
              fail(ex.getMessage());
         } finally{
-             SOAPFaultBuilder.setCaptureExceptionMessage(true);
+             SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
     public void testCreate12FaultFromRE() {
         RuntimeException re = new RuntimeException(
                 "XML reader error: com.ctc.wstx.exc.WstxParsingException: Unexpected < character in element");
+
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_12, null, re);
@@ -147,11 +151,13 @@ public class SOAPFaultBuilderTest extends TestCase {
             ex.printStackTrace();
             fail(ex.getMessage());
         } finally {
-            SOAPFaultBuilder.setCaptureExceptionMessage(true);
+            SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
     public void testCreateSOAPFaultMessageWithSOAPFaultArgumentForSOAP11() {
+
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_11, FAULT_11);
@@ -160,7 +166,7 @@ public class SOAPFaultBuilderTest extends TestCase {
             ex.printStackTrace();
             fail(ex.getMessage());
         } finally {
-            SOAPFaultBuilder.setCaptureExceptionMessage(true);
+            SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
@@ -169,6 +175,8 @@ public class SOAPFaultBuilderTest extends TestCase {
         String faultString = "Couldn't create SOAP message due to exception: XML reader error: "
                 + "com.ctc.wstx.exc.WstxParsingException: Unexpected '&lt;' character in element "
                 + "(missing closing '>'?)";
+
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_11, faultString, DETAIL1_QNAME);
@@ -177,11 +185,13 @@ public class SOAPFaultBuilderTest extends TestCase {
             ex.printStackTrace();
             fail(ex.getMessage());
         } finally {
-            SOAPFaultBuilder.setCaptureExceptionMessage(true);
+            SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
     public void testCreateSOAPFaultMessageWithSOAPFaultArgumentForSOAP12() {
+
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_12, FAULT_12);
@@ -190,7 +200,7 @@ public class SOAPFaultBuilderTest extends TestCase {
             ex.printStackTrace();
             fail(ex.getMessage());
         } finally {
-            SOAPFaultBuilder.setCaptureExceptionMessage(true);
+            SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
@@ -199,6 +209,8 @@ public class SOAPFaultBuilderTest extends TestCase {
         String faultString = "Couldn't create SOAP message due to exception: XML reader error: "
                 + "com.ctc.wstx.exc.WstxParsingException: Unexpected '&lt;' character in element "
                 + "(missing closing '>'?)";
+
+        boolean captureExceptionMessageOldValue = SOAPFaultBuilder.isCaptureExceptionMessage();
         try {
             SOAPFaultBuilder.setCaptureExceptionMessage(false);
             Message faultMsg = SOAPFaultBuilder.createSOAPFaultMessage(SOAPVersion.SOAP_12, faultString,
@@ -208,7 +220,7 @@ public class SOAPFaultBuilderTest extends TestCase {
             ex.printStackTrace();
             fail(ex.getMessage());
         } finally {
-            SOAPFaultBuilder.setCaptureExceptionMessage(true);
+            SOAPFaultBuilder.setCaptureExceptionMessage(captureExceptionMessageOldValue);
         }
     }
 
@@ -255,7 +267,7 @@ public class SOAPFaultBuilderTest extends TestCase {
                 if (rdr.getName().getLocalPart().equals("faultstring")) {
                     isfaultStringPresent = true;
                     event = rdr.next();
-                    assertEquals(SOAPFaultBuilder.SERVER_ERROR, rdr.getText());
+                    assertEquals("Server Error", rdr.getText());
                 }
             }
         }
@@ -270,6 +282,6 @@ public class SOAPFaultBuilderTest extends TestCase {
         assertTrue(ex instanceof SOAPFaultException);
         SOAPFaultException sfe = (SOAPFaultException) ex;
         SOAPFault sf = sfe.getFault();
-        assertEquals(sf.getFaultString(),SOAPFaultBuilder.SERVER_ERROR);
+        assertEquals(sf.getFaultString(),"Server Error");
     }
 }

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java
@@ -270,6 +270,6 @@ public class SOAPFaultBuilderTest extends TestCase {
         assertTrue(ex instanceof SOAPFaultException);
         SOAPFaultException sfe = (SOAPFaultException) ex;
         SOAPFault sf = sfe.getFault();
-        assertTrue(sf.getFaultString().equals(SOAPFaultBuilder.SERVER_ERROR));
+        assertEquals(sf.getFaultString(),SOAPFaultBuilder.SERVER_ERROR);
     }
 }


### PR DESCRIPTION
As of now, SOAP response packet contains faultString which contains detailed error message in case of any SOAP Fault.

The customer has a requirement where they do not want any exception messages to be displayed in the faultString for security concerns.

For the same reason, a fix was introduced for BUG34600318 where a new system property com.sun.xml.ws.fault.SOAPFaultBuilder.captureExceptionMessage=false
has been added to simulate customer intended behavior.

This bug is intended to address the same issue but to include all possible cases which has been missed in the previous BUG34600318.

Added more testcases in file:
./jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/fault/SOAPFaultBuilderTest.java

Signed-off-by: Himanshu Ranjan <himanshu.ranjan@oracle.com>