### PR TITLE
Removed obselete warning about non-standard soap 1.2

### DIFF
--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -303,9 +303,7 @@ public class WSDLModeler extends WSDLModelerBase {
                         }
                     }else{
                         // we can only do soap1.2 if extensions are on
-                        if (options.isExtensionMode()) {
-                            warning(wsdlPort, ModelerMessages.WSDLMODELER_WARNING_PORT_SOAP_BINDING_12(wsdlPort.getName()));
-                        } else {
+                        if (!options.isExtensionMode()) {
                             warning(wsdlPort, ModelerMessages.WSDLMODELER_WARNING_IGNORING_SOAP_BINDING_12(wsdlPort.getName()));
                             return false;
                         }


### PR DESCRIPTION
Removed warning about SOAP 1.2 being non-standard when SOAP 1.2 extensions are enabled. 

SOAP 1.2 (https://www.w3.org/TR/soap12-part1/ ) was released over a decade ago in 2007  and is no longer considered non-standard. In order to use soap 1.2 features the soap 1.2 extension mode must be explicitly enabled, so wsimport should not give warnings that the user is using SOAP 1.2 features.