### PR TITLE
Revert:  Removed obselete warning about non-standard soap 1.2 #700 

### DIFF
--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/modeler/wsdl/WSDLModeler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -303,7 +303,9 @@ public class WSDLModeler extends WSDLModelerBase {
                         }
                     }else{
                         // we can only do soap1.2 if extensions are on
-                        if (!options.isExtensionMode()) {
+                        if (options.isExtensionMode()) {
+                            warning(wsdlPort, ModelerMessages.WSDLMODELER_WARNING_PORT_SOAP_BINDING_12(wsdlPort.getName()));
+                        } else {
                             warning(wsdlPort, ModelerMessages.WSDLMODELER_WARNING_IGNORING_SOAP_BINDING_12(wsdlPort.getName()));
                             return false;
                         }


### PR DESCRIPTION
We were discussing this @lukasj and me by zoom and he asked me to revert this because the warning is currently correct since the xml-ws spec considers SOAP 1.2 as to be supported in the future (see https://jakarta.ee/specifications/xml-web-services/4.0/jakarta-xml-ws-spec-4.0#goals ) and is currently optional (search through the spec for "SOAP 1.2" to learn more).

acceptable form of this change can be:
- full update through the XML-WS spec as well as the implementation and addition of new TCKs

or

- addition of an option to suppress warnings like this, instead of forcing it.

PR was: https://github.com/eclipse-ee4j/metro-jax-ws/pull/700