### PR TITLE
Updated gmbal with fixed jpms and osgi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,6 @@ updates:
       # istack >= 4.2.0 has no SecurityManager
       - dependency-name: "com.sun.istack:*"
         versions: [ ">=4.2.0" ]
-      # gmbal >= 4.1.0 changed the module name
-      - dependency-name: "org.glassfish.gmbal:*"
-        versions: [ ">=4.1.0" ]
     groups:
       maven-plugins:
         patterns:

--- a/jaxws-ri/boms/bom-ext/pom.xml
+++ b/jaxws-ri/boms/bom-ext/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <ant.version>1.10.15</ant.version>
-        <!-- CQ 21208 -->
         <asm.version>9.9.1</asm.version>
         <eclipselink.version>4.0.9</eclipselink.version>
         <junit.version>4.13.2</junit.version>

--- a/jaxws-ri/boms/bom/pom.xml
+++ b/jaxws-ri/boms/bom/pom.xml
@@ -31,23 +31,24 @@
     <description>JAX-WS Reference Implementation Bill-of-Materials (BOM)</description>
 
     <properties>
-        <!--************************************************************-->
-
-        <istack.plugin.version>4.1.2</istack.plugin.version>
-        <gmbal-api.version>4.0.3</gmbal-api.version>
+        <activation-api.version>2.1.4</activation-api.version>
+        <angus-activation.version>2.0.3</angus-activation.version>
+        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <fastinfoset.version>2.1.1</fastinfoset.version>
+        <gmbal.version>4.1.0</gmbal.version>
         <ha-api.version>3.1.13</ha-api.version>
+        <istack.plugin.version>4.1.2</istack.plugin.version>
+        <jaxb-api.version>4.0.4</jaxb-api.version>
         <jaxb.version>4.0.6</jaxb.version>
-        <xml.ws-api.version>4.0.2</xml.ws-api.version>
         <management-api.version>3.3.0</management-api.version>
         <mimepull.version>1.10.0</mimepull.version>
         <saaj-api.version>3.0.2</saaj-api.version>
         <saaj-impl.version>3.0.4</saaj-impl.version>
         <streambuffer.version>2.1.0</streambuffer.version>
-        <woodstox-core.version>7.1.1</woodstox-core.version>
+        <stax-api.version>2.1.0</stax-api.version>
         <stax2-api.version>4.2.2</stax2-api.version>
-        <activation-api.version>2.1.4</activation-api.version>
-        <angus-activation.version>2.0.3</angus-activation.version>
-        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <woodstox-core.version>7.1.1</woodstox-core.version>
+        <xml.ws-api.version>4.0.2</xml.ws-api.version>
     </properties>
 
     <dependencyManagement>
@@ -99,13 +100,13 @@
             <dependency>
                 <groupId>org.glassfish.gmbal</groupId>
                 <artifactId>gmbal-api-only</artifactId>
-                <version>${gmbal-api.version}</version>
+                <version>${gmbal.version}</version>
                 <classifier>sources</classifier>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.gmbal</groupId>
                 <artifactId>gmbal</artifactId>
-                <version>${gmbal-api.version}</version>
+                <version>${gmbal.version}</version>
                 <classifier>sources</classifier>
             </dependency>
             <dependency>
@@ -178,12 +179,12 @@
             <dependency>
                 <groupId>org.glassfish.gmbal</groupId>
                 <artifactId>gmbal-api-only</artifactId>
-                <version>${gmbal-api.version}</version>
+                <version>${gmbal.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.gmbal</groupId>
                 <artifactId>gmbal</artifactId>
-                <version>${gmbal-api.version}</version>
+                <version>${gmbal.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>

--- a/jaxws-ri/bundles/jaxws-rt/pom.xml
+++ b/jaxws-ri/bundles/jaxws-rt/pom.xml
@@ -45,7 +45,7 @@
 
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal-api-only</artifactId>
+            <artifactId>gmbal</artifactId>
         </dependency>
 
         <dependency>

--- a/jaxws-ri/bundles/jaxws-rt/src/main/java/module-info.java
+++ b/jaxws-ri/bundles/jaxws-rt/src/main/java/module-info.java
@@ -44,8 +44,9 @@ module com.sun.xml.ws {
     requires transitive com.sun.xml.bind;
     requires transitive com.sun.xml.fastinfoset;
     requires transitive com.sun.xml.streambuffer;
-    requires transitive gmbal;
     requires transitive org.glassfish.ha.api;
+    requires org.glassfish.external.management.api;
+    requires transitive org.glassfish.gmbal.impl;
 
     exports com.sun.xml.ws.policy;
     exports com.sun.xml.ws.policy.sourcemodel;

--- a/jaxws-ri/extras/eclipselink_sdo/pom.xml
+++ b/jaxws-ri/extras/eclipselink_sdo/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>jaxb-xjc</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/jaxws-ri/extras/helidon-integration/se/pom.xml
+++ b/jaxws-ri/extras/helidon-integration/se/pom.xml
@@ -69,12 +69,6 @@
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>rt</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.gmbal</groupId>
-                    <artifactId>gmbal-api-only</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/jaxws-ri/runtime/rt/pom.xml
+++ b/jaxws-ri/runtime/rt/pom.xml
@@ -58,8 +58,9 @@
             <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jvnet.staxex</groupId>
-            <artifactId>stax-ex</artifactId>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.stream.buffer</groupId>

--- a/jaxws-ri/runtime/rt/src/main/java/module-info.java
+++ b/jaxws-ri/runtime/rt/src/main/java/module-info.java
@@ -21,7 +21,6 @@
  *
  * @since 2.4.0
  */
-@SuppressWarnings({"deprecation"})
 module com.sun.xml.ws.rt {
 
     requires java.desktop;
@@ -41,13 +40,16 @@ module com.sun.xml.ws.rt {
     requires static jakarta.servlet;
     requires static com.sun.xml.fastinfoset;
 
-    requires transitive org.jvnet.mimepull;
-    requires transitive org.jvnet.staxex;
-    requires transitive org.glassfish.jaxb.runtime;
     requires transitive com.sun.xml.streambuffer;
     requires transitive com.sun.xml.ws.policy;
-    requires transitive gmbal;
+    requires transitive org.glassfish.gmbal.api;
     requires transitive org.glassfish.ha.api;
+    requires transitive org.glassfish.jaxb.runtime;
+    requires transitive org.jvnet.mimepull;
+    requires transitive org.jvnet.staxex;
+
+    requires org.glassfish.external.management.api;
+    requires org.glassfish.pfl.tf;
 
     exports com.oracle.webservices.api;
     exports com.oracle.webservices.api.databinding;
@@ -145,7 +147,7 @@ module com.sun.xml.ws.rt {
     opens com.oracle.xmlns.webservices.jaxws_databinding to jakarta.xml.bind;
 
     opens com.sun.xml.ws.api.message;
-    
+
     uses jakarta.xml.ws.spi.Provider;
     uses jakarta.xml.soap.MessageFactory;
     uses jakarta.xml.soap.SAAJMetaFactory;

--- a/jaxws-ri/runtime/servlet/src/main/java/module-info.java
+++ b/jaxws-ri/runtime/servlet/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module com.sun.xml.ws.servlet {
     requires transitive com.sun.xml.ws.rt;
     requires java.logging;
     requires transitive jakarta.servlet;
+    requires org.glassfish.external.management.api;
 
     exports com.sun.xml.ws.developer.servlet;
     exports com.sun.xml.ws.server.servlet;


### PR DESCRIPTION
- gmbal-api compiles, but to run we need the implementation of `ManagedObjectManagerService` loaded by `ManagedObjectManagerFactory`. Such implementation exists just one if I am not mistaken.
- We should change some things later, ie. use own fake implementation for testing to detach from gmbal dependency.
- There is some slow progress to make the dependency management easier and more logical, JPMS enforces and helps with this direction.
- See also https://github.com/eclipse-ee4j/orb-gmbal/releases/tag/4.1.0 and especially https://github.com/eclipse-ee4j/orb-gmbal/pull/56
- Note that previous state was dysfunctional, GlassFish worked with Metro because JPMS was removed from the `webservices-osgi.jar` file used by GF.
- This PR is a first step; more are needed, but probably will not affect Metro+RI, because they are related rather to corba-orb runtime lifecycle and insane lazy init using incompletely initialized instances, which is pretty fragile.
- Note: metro-wsit using this snapshot passed own tests locally, however I will yet push there a PR bound to this change. It is still rather a bugfix than a breaking change.