### PR TITLE
Fixed project name used to identify the deployment on maven central

### DIFF
--- a/jaxws-ri/boms/bom/pom.xml
+++ b/jaxws-ri/boms/bom/pom.xml
@@ -353,7 +353,7 @@
         <profile>
             <id>oss-release</id>
             <properties>
-                <release.projectName>Eclipse JAX-WS RI ${project.version}</release.projectName>
+                <release.projectName>Eclipse JAX-WS RI</release.projectName>
                 <!-- Do not autopublish by default -->
                 <release.autoPublish>false</release.autoPublish>
                 <!-- By default block until everything is really published -->


### PR DESCRIPTION
- the version is already in the parent's configuration, this is really just the project name.