### PR TITLE
Issue #760 Fixed XmlDataContentHandler charset processing

### DIFF
--- a/jaxws-ri/pom.xml
+++ b/jaxws-ri/pom.xml
@@ -51,6 +51,7 @@
         <spotbugs.version>4.9.8.3</spotbugs.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <junit.version>4.13.2</junit.version>
+        <hamcrest.version>3.0</hamcrest.version>
 
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
@@ -783,6 +784,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/jaxws-ri/runtime/rt/pom.xml
+++ b/jaxws-ri/runtime/rt/pom.xml
@@ -118,7 +118,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/ContentType.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/ContentType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -7,12 +8,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
-/*
- * @(#)ContentType.java       1.7 02/03/27
- */
-
-
 
 package com.sun.xml.ws.encoding;
 
@@ -23,21 +18,20 @@ import jakarta.xml.ws.WebServiceException;
  * methods to parse a ContentType string into individual components
  * and to generate a MIME style ContentType string.
  *
- * @version 1.7, 02/03/27
- * @author  John Mani
+ * @author  John Mani 2002
  */
 public final class ContentType {
 
-    private String primaryType;	// primary type
-    private String subType;	// subtype
-    private ParameterList list;	// parameter list
+    private String primaryType;    // primary type
+    private String subType;    // subtype
+    private ParameterList list;    // parameter list
 
     /**
      * Constructor that takes a Content-Type string. The String
      * is parsed into its constituents: primaryType, subType
      * and parameters. A ParseException is thrown if the parse fails.
      *
-     * @param	s	the Content-Type string.
+     * @param    s    the Content-Type string.
      * @exception WebServiceException if the parse fails.
      */
     public ContentType(String s) throws WebServiceException {
@@ -47,18 +41,18 @@ public final class ContentType {
         // First "type" ..
         tk = h.next();
         if (tk.getType() != HeaderTokenizer.Token.ATOM)
-            throw new WebServiceException();
+            throw new WebServiceException("Expected MIME type in Content-Type value: " + s);
         primaryType = tk.getValue();
 
         // The '/' separator ..
         tk = h.next();
         if ((char)tk.getType() != '/')
-            throw new WebServiceException();
+            throw new WebServiceException("Expected '/' separator in Content-Type value: " + s);
 
         // Then "subType" ..
         tk = h.next();
         if (tk.getType() != HeaderTokenizer.Token.ATOM)
-            throw new WebServiceException();
+            throw new WebServiceException("Expected subtype in Content-Type value: " + s);
         subType = tk.getValue();
 
         // Finally parameters ..
@@ -73,7 +67,7 @@ public final class ContentType {
      * @return the primary type
      */
     public String getPrimaryType() {
-	    return primaryType;
+        return primaryType;
     }
 
     /**
@@ -81,7 +75,7 @@ public final class ContentType {
      * @return the subType
      */
     public String getSubType() {
-	    return subType;
+        return subType;
     }
 
     /**
@@ -92,7 +86,7 @@ public final class ContentType {
      * @return the type
      */
     public String getBaseType() {
-	    return primaryType + '/' + subType;
+        return primaryType + '/' + subType;
     }
 
     /**
@@ -100,7 +94,7 @@ public final class ContentType {
      * if this parameter is absent.
      *
      * @param name parameter name
-     * @return	parameter value
+     * @return    parameter value
      */
     public String getParameter(String name) {
         if (list == null)
@@ -113,10 +107,10 @@ public final class ContentType {
      * Return a ParameterList object that holds all the available
      * parameters. Returns null if no parameters are available.
      *
-     * @return	ParameterList
+     * @return    ParameterList
      */
     /* package */ ParameterList getParameterList() {
-	    return list;
+        return list;
     }
 
 }

--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/XmlDataContentHandler.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/encoding/XmlDataContentHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -15,16 +16,18 @@ import com.sun.xml.ws.util.xml.XmlUtil;
 import jakarta.activation.ActivationDataFlavor;
 import jakarta.activation.DataContentHandler;
 import jakarta.activation.DataSource;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.Arrays;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
 /**
  * JAF data handler for XML content
@@ -60,24 +63,25 @@ public class XmlDataContentHandler implements DataContentHandler {
     }
 
     /**
-     * Create an object from the input stream
+     * Wraps the provided {@link DataSource} to a {@link StreamSource}
      */
     @Override
     public Object getContent(DataSource ds) throws IOException {
-        String ctStr = ds.getContentType();
-        String charset = null;
-        if (ctStr != null) {
-            ContentType ct = new ContentType(ctStr);
-            if (!isXml(ct)) {
+        final String ctStr = ds.getContentType();
+        final String charset;
+        if (ctStr == null) {
+            charset = null;
+        } else {
+            ContentType contentType = new ContentType(ctStr);
+            if (!isXml(contentType)) {
                 throw new IOException(
-                    "Cannot convert DataSource with content type \""
-                            + ctStr + "\" to object in XmlDataContentHandler");
+                    "Cannot convert DataSource with content type \"" + ctStr + "\" to object in XmlDataContentHandler");
             }
-            charset = ct.getParameter("charset");
+            charset = contentType.getParameter("charset");
         }
-        return (charset != null)
-                ? new StreamSource(new InputStreamReader(ds.getInputStream()), charset)
-                : new StreamSource(ds.getInputStream());
+        return charset == null
+            ? new StreamSource(ds.getInputStream())
+            : new StreamSource(new InputStreamReader(ds.getInputStream(), charset));
     }
 
     /**

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/encoding/XmlDataContentHandlerTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/encoding/XmlDataContentHandlerTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,13 +11,27 @@
 
 package com.sun.xml.ws.encoding;
 
+import jakarta.activation.DataSource;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import jakarta.activation.DataSource;
+import java.nio.charset.UnsupportedCharsetException;
+
+import javax.xml.transform.stream.StreamSource;
+
 import junit.framework.TestCase;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assume.assumeNoException;
 
 /**
  * Test JAF data handler for XML content.
@@ -41,13 +56,16 @@ public class XmlDataContentHandlerTest extends TestCase {
         /**
          * Creates an instance of dummy data source.
          * @param name Data source name.
-         * @param contentType Content type.
+         * @param mimeType Content type.
          */
-        private DataSourceMockUp(final String name, final String contentType) {
+        private DataSourceMockUp(final String name, final String contentType, final String charset) {
+            this(name, new byte[0], contentType, charset);
+        }
+
+        private DataSourceMockUp(final String name, final byte[] body, final String contentType, final String charset) {
             this.name = name;
-            this.contentType = contentType;
-            final byte[] buffIn = ("Content type: " + contentType).getBytes(Charset.forName("UTF-8"));
-            is = new ByteArrayInputStream(buffIn);
+            this.contentType = contentType + (charset == null ? "" : ("; charset=" + charset));
+            this.is = new ByteArrayInputStream(body);
         }
 
         /**
@@ -103,37 +121,80 @@ public class XmlDataContentHandlerTest extends TestCase {
      * of {@link XmlDataContentHandler} class with lower case mime type.
      */
     public void testIsXmlLowerCase() throws Exception {
-        checkIsXml("application/xml");
+        checkIsXml("application/xml", UTF_8.name());
     }
 
     /**
      * Test MIME type processing in {@code isXml(ContentType)} method
      * of {@link XmlDataContentHandler} class with upper case mime type.
      */
-    public void testIsXmlUpperCase() throws ClassNotFoundException, IOException {
-        checkIsXml("APPLICATION/XML");
+    public void testIsXmlUpperCase() throws Exception {
+        checkIsXml("APPLICATION/XML", UTF_8.name());
     }
 
     /**
      * Test MIME type processing in {@code isXml(ContentType)} method
      * of {@link XmlDataContentHandler} class with mixed case mime type.
      */
-    public void testIsXmlMixedCase() throws ClassNotFoundException, IOException {
-        checkIsXml("application/XML");
+    public void testIsXmlMixedCase() throws Exception {
+        checkIsXml("application/XML", UTF_8.name());
+    }
+
+    /**
+     * Test MIME type processing in {@code isXml(ContentType)} method
+     * of {@link XmlDataContentHandler} class with mixed case mime type.
+     */
+    public void testContentType_incompatibleCharset() throws Exception {
+        String mimeType = "application/xml";
+        XmlDataContentHandler handler = new XmlDataContentHandler();
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<body>Příliš žluťoučký kůň</body>\n";
+        DataSource ds = new DataSourceMockUp("dummy", xml.getBytes(UTF_8), mimeType, ISO_8859_1.name());
+        StreamSource content = (StreamSource) handler.getContent(ds);
+        assertNull(content.getInputStream());
+        Reader reader = content.getReader();
+        assertNotNull(reader);
+        CharBuffer buffer = CharBuffer.allocate(8192);
+        assertEquals(82, reader.read(buffer));
+        String output = buffer.rewind().toString();
+        // To prove that the charset was respected - and broke the file content.
+        assertThat(output, stringContainsInOrder("<?xml", "<body>", "¾", "</body>"));
+    }
+
+    /**
+     * Test MIME type processing in {@code isXml(ContentType)} method
+     * of {@link XmlDataContentHandler} class with mixed case mime type.
+     */
+    public void testContentType_wrongCharsetInXml() throws Exception {
+        try {
+            Charset.forName("ISO-8859-2");
+        } catch (UnsupportedCharsetException e) {
+            assumeNoException("Ignoring test because the required charset is not supported on this system.", e);
+        }
+        String mimeType = "application/xml";
+        XmlDataContentHandler handler = new XmlDataContentHandler();
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<body>Příliš žluťoučký kůň</body>\n";
+        DataSource ds = new DataSourceMockUp("dummy", xml.getBytes("ISO-8859-2"), mimeType, "iso-8859-2");
+        StreamSource content = (StreamSource) handler.getContent(ds);
+        assertNull(content.getInputStream());
+        Reader reader = content.getReader();
+        assertNotNull(reader);
+        CharBuffer buffer = CharBuffer.allocate(8192);
+        assertEquals(73, reader.read(buffer));
+        String output = buffer.rewind().toString();
+        // The string is not equal for some reason
+        assertThat(output, stringContainsInOrder(xml));
     }
 
     /**
      * Test MIME type processing in {@code isXml(ContentType)} method of {@link XmlDataContentHandler} class.
      * @param mimeType MIME type to be tested.
      */
-    private void checkIsXml(final String mimeType) throws ClassNotFoundException {
+    private void checkIsXml(final String mimeType, String charset) throws ClassNotFoundException, IOException {
         XmlDataContentHandler handler = new XmlDataContentHandler();
-        DataSource ds = new DataSourceMockUp("dummy", mimeType);
-        try {
-            handler.getContent(ds);
-        } catch (IOException ex) {
-            fail(ex.getMessage());
-        }
+        DataSource ds = new DataSourceMockUp("dummy", mimeType, charset);
+        assertThat(handler.getContent(ds), instanceOf(StreamSource.class));
     }
 
 }


### PR DESCRIPTION
- Fixes #760 
- Added exception messages - without them I was completely lost with the first test version where I put also the http header name to the content type.
- A bit of code cleanup in the getContent - the bug was right brace on a wrong place
- I wrote two tests to ensure that the content type charset is respected.