### PR TITLE
Dependency check moved to own job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: 17
         cache: maven
 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+# Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Distribution License v. 1.0, which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+name: JAXWS RI Dependency Check
+
+on:
+  schedule:
+    - cron: '35 20 * * 2'
+
+jobs:
+  build:
+    name: Test on JDK ${{ matrix.java_version }}
+    runs-on: ubuntu-latest
+    outputs:
+      jdk: ${{ steps.build.outputs.jdk }}
+    strategy:
+      matrix:
+        java_version: [ 21 ]
+
+    steps:
+      - name: Checkout for build
+        uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java_version }}
+          cache: maven
+      - name: Cache OWASP Dependency-Check Data
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data/
+          key: ${{ runner.os }}-dc-nvd-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-dc-nvd-
+      - name: Verify
+        id: build
+        run: |
+          cd jaxws-ri
+          mvn -B -V -Poss-release,dependency-check,snapshots clean verify -Dgpg.skip=true -DskipSBOM -Dittest=true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,21 +33,14 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
           cache: maven
-      - name: Cache OWASP Dependency-Check Data
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data/
-          key: ${{ runner.os }}-dc-nvd-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-dc-nvd-
       - name: Verify
         id: build
         run: |
           cd jaxws-ri
-          mvn -B -V -Poss-release,dependency-check,snapshots clean verify -Dgpg.skip=true -DskipSBOM -Dittest=true
+          mvn -B -V -Poss-release,snapshots clean verify -Dgpg.skip=true -DskipSBOM -Dittest=true
           cd ..
           echo "jdk=${{ matrix.java_version }}" >> $GITHUB_OUTPUT
       - name: Upload binary image
@@ -71,7 +64,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ needs.build.outputs.jdk }}
       - name: Checkout tests
         uses: actions/checkout@v6


### PR DESCRIPTION
- The OWASP db changes in time, so it is probably better to check current master than PRs
- The OWASP db prohibits repeating downloads, so builds became quite fragile
- I have switched JDK also from zulu to temurin
- Current master locally failed, but I have own token to the remote website, I am not sure how to set it for GitHub Action job.

```
mvn clean install -Pdependency-check
...
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 
[ERROR] 
[ERROR] relaxng-datatype-4.0.8-SNAPSHOT.jar (pkg:maven/com.sun.xml.bind.external/relaxng-datatype@4.0.8-SNAPSHOT, cpe:2.3:a:eclipse:glassfish:4.0.8:snapshot:*:*:*:*:*:*): CVE-2026-2586(9.1), CVE-2026-2587(9.6)
[ERROR] rngom-4.0.8-SNAPSHOT.jar (pkg:maven/com.sun.xml.bind.external/rngom@4.0.8-SNAPSHOT, cpe:2.3:a:eclipse:glassfish:4.0.8:snapshot:*:*:*:*:*:*): CVE-2026-2586(9.1), CVE-2026-2587(9.6)
[ERROR] 
[ERROR] See the dependency-check report for more details.

```