### PR TITLE
Updated JAXB

### DIFF
--- a/jaxws-ri/boms/bom/pom.xml
+++ b/jaxws-ri/boms/bom/pom.xml
@@ -86,8 +86,8 @@
         <gmbal.version>4.1.2</gmbal.version>
         <ha-api.version>3.1.13</ha-api.version>
         <istack.plugin.version>4.1.2</istack.plugin.version>
-        <jaxb-api.version>4.0.4</jaxb-api.version>
-        <jaxb.version>4.0.6</jaxb.version>
+        <jaxb-api.version>4.0.5</jaxb-api.version>
+        <jaxb.version>4.0.8</jaxb.version>
         <management-api.version>3.3.0</management-api.version>
         <mimepull.version>1.11.0</mimepull.version>
         <saaj-api.version>3.0.2</saaj-api.version>


### PR DESCRIPTION
See https://github.com/eclipse-ee4j/jaxb-ri/releases/tag/4.0.8-RI

Important - `com.sun.xml.bind` changed to `org.glassfish.jaxb` for some of artifacts and the team did not publish the relocation pom yet, that is why dependabot did not see this change. EDIT: Nope, it still doesn't make sense.

See https://github.com/eclipse-ee4j/jaxb-ri/pull/1956/changes