### PR TITLE
Improvements of the owasp dependency check

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -9,40 +9,55 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+# See https://dependency-check.github.io/DependencyCheck/data/cache-action.html
 name: JAXWS RI Dependency Check
 
 on:
   schedule:
     - cron: '35 20 * * 2'
-
+  workflow_dispatch:
+      inputs:
+        drop-owasp-cache:
+          description: 'Drop the downloaded cache the CVE database'
+          required: true
+          default: false
+          type: boolean
 jobs:
-  build:
-    name: Test on JDK ${{ matrix.java_version }}
+  owasp-scan:
+    if: github.actor != 'dependabot[bot]'
+    name: OWASP Scan
     runs-on: ubuntu-latest
-    outputs:
-      jdk: ${{ steps.build.outputs.jdk }}
-    strategy:
-      matrix:
-        java_version: [ 21 ]
-
     steps:
-      - name: Checkout for build
-        uses: actions/checkout@v6
-      - name: Set up JDK
+      - uses: actions/checkout@v6
+      - name: Setup JDK
         uses: actions/setup-java@v5
         with:
+          java-version: '21'
           distribution: 'temurin'
-          java-version: ${{ matrix.java_version }}
-          cache: maven
-      - name: Cache OWASP Dependency-Check Data
-        uses: actions/cache@v5
+          cache: 'maven'
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "datetime=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Restore Cached Maven Dependencies
+        if: ${{ inputs.drop-owasp-cache == false }}
+        uses: actions/cache/restore@v3
         with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data/
-          key: ${{ runner.os }}-dc-nvd-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          # Using datetime in cache key as OWASP database may change, without the pom changing
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-dc-nvd-
-      - name: Verify
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}
+            ${{ runner.os }}-maven-
+      - name: Build and Scan
         id: build
         run: |
           cd jaxws-ri
-          mvn -B -V -Poss-release,dependency-check,snapshots clean verify -Dgpg.skip=true -DskipSBOM -Dittest=true
+          mvn -B -V -fae -Poss-release,dependency-check,snapshots clean verify -Dgpg.skip=true -DskipSBOM -Dittest=true -DskipTests -DskipITs -DnvdApiKey=${{secrets.NVD_API_KEY}}
+      - name: Cache Maven Dependencies
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}

--- a/jaxws-ri/boms/bom/pom.xml
+++ b/jaxws-ri/boms/bom/pom.xml
@@ -87,7 +87,7 @@
         <ha-api.version>3.1.13</ha-api.version>
         <istack.plugin.version>4.1.2</istack.plugin.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
-        <jaxb.version>4.0.8</jaxb.version>
+        <jaxb.version>4.0.9</jaxb.version>
         <management-api.version>3.3.0</management-api.version>
         <mimepull.version>1.11.0</mimepull.version>
         <saaj-api.version>3.0.2</saaj-api.version>


### PR DESCRIPTION
* Seems we will have to use suppressions as the owasp check still has false positives - the plugin reports CVE related to Admin UI of GlassFish to JAXB modules. For now, I am ignoring that, GF will release 8.0.3 in few days, it will be interesting to see if the Metro validation then stops failing or not. As suppressions cannot be inlined in poms, I would rather prefer avoiding the creation of required files or even modules.

* The build can be executed manually.

* Relates to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7537 which created the required secret token.