### PR TITLE
Generate the absolute WSDL location through java.net.URI

### DIFF
--- a/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/generator/ServiceGenerator.java
+++ b/jaxws-ri/tools/wscompile/src/main/java/com/sun/tools/ws/processor/generator/ServiceGenerator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -47,6 +48,8 @@ import org.xml.sax.Locator;
 
 import javax.xml.namespace.QName;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.ServiceLoader;
@@ -242,7 +245,9 @@ public class ServiceGenerator extends GeneratorBase {
            URL url = null;
            WebServiceException e = null;
            try {
-                url = new URL("http://ExampleService.wsdl");
+                url = new URI("http://ExampleService.wsdl").toURL();
+           } catch (URISyntaxException ex) {
+                e = new WebServiceException(ex);
            } catch (MalformedURLException ex) {
                 e = new WebServiceException(ex);
            }
@@ -254,15 +259,24 @@ public class ServiceGenerator extends GeneratorBase {
         JBlock staticBlock = cls.init();
         JVar urlVar = staticBlock.decl(cm.ref(URL.class), "url", JExpr._null());
         JVar exVar = staticBlock.decl(cm.ref(WebServiceException.class), "e", JExpr._null());
-        
+
         JTryBlock tryBlock = staticBlock._try();
-        tryBlock.body().assign(urlVar, JExpr._new(cm.ref(URL.class)).arg(wsdlLocation));
-        JCatchBlock catchBlock = tryBlock._catch(cm.ref(MalformedURLException.class));
-        catchBlock.param("ex");
-        catchBlock.body().assign(exVar, JExpr._new(cm.ref(WebServiceException.class)).arg(JExpr.ref("ex")));
+        tryBlock.body().assign(urlVar, JExpr._new(cm.ref(URI.class)).arg(wsdlLocation).invoke("toURL"));
+        // codemodel cannot generate a multi-catch, so both failures get their own block
+        writeWSDLLocationCatch(tryBlock, URISyntaxException.class, exVar);
+        writeWSDLLocationCatch(tryBlock, MalformedURLException.class, exVar);
 
         staticBlock.assign(urlField, urlVar);
         staticBlock.assign(exField, exVar);
+    }
+
+    /*
+       Appends "catch (<exception> ex) { e = new WebServiceException(ex); }" to the given try block.
+    */
+    private void writeWSDLLocationCatch(JTryBlock tryBlock, Class<? extends Exception> exception, JVar exVar) {
+        JCatchBlock catchBlock = tryBlock._catch(cm.ref(exception));
+        JVar param = catchBlock.param("ex");
+        catchBlock.body().assign(exVar, JExpr._new(cm.ref(WebServiceException.class)).arg(param));
     }
 
     /*


### PR DESCRIPTION
Fixes #817

`ServiceGenerator.writeAbsWSDLLocation` now builds the WSDL location with
`new URI(<location>).toURL()` instead of the `java.net.URL(String)` constructor deprecated since
Java 20. The warning it produced landed in code users cannot act on — the service class is
regenerated on every build and no wsimport option changes its shape.

### Generated output

Before:

```java
try {
    url = new URL("http://example.org/hello?wsdl");
} catch (MalformedURLException ex) {
    e = new WebServiceException(ex);
}
```

After:

```java
try {
    url = new URI("http://example.org/hello?wsdl").toURL();
} catch (URISyntaxException ex) {
    e = new WebServiceException(ex);
} catch (MalformedURLException ex) {
    e = new WebServiceException(ex);
}
```

### Why not `URI.create(...)`, and why two catch blocks

`URI.create(...)` reads better but throws unchecked `IllegalArgumentException`, which would escape
the static initializer. Today a location that cannot be turned into a URL is stored in the
`_EXCEPTION` field and rethrown as a `WebServiceException` when the service is constructed; with
`URI.create` a malformed location would instead surface as an `ExceptionInInitializerError` on
first use of the class. `new URI(String)` keeps the failure checked, and both it and `URI.toURL()`
throw, so both are caught. codemodel cannot generate a multi-catch — `JCatchBlock` holds a single
exception type — hence two blocks rather than `catch (URISyntaxException | MalformedURLException ex)`.

### Known behaviour change

`new URI(String)` is stricter than `new URL(String)`; a location containing a character that is
illegal in a URI but tolerated by `URL` (a literal space, `{`, `}`, `|`, `^`) now ends up in the
`_EXCEPTION` field instead of producing a URL. Such a `-wsdllocation` was never a legal URI, and
the failure is reported through the same channel as any other malformed location.

### Left alone on purpose

`writeClassLoaderBaseResourceWSDLLocation` (`-XuseBaseResourceAndURLToLoadWSDL`) keeps its
deprecated `new URL(URL, String)`. Its context is `Xxx.class.getResource(".")`, which for a class
loaded from a jar is an opaque `jar:` URI, and `URI.resolve` against an opaque base returns the
argument unchanged — `context.toURI().resolve(spec).toURL()` fails with
`IllegalArgumentException: URI is not absolute`. Converting that site would break jar-packaged
services, so it needs a different approach and is out of scope here.

### Verification

wsimport was run over the existing `hello.wsdl` test fixture with an absolute location, and the
whole generated tree compiled on JDK 25 with deprecation warnings promoted to errors:

```
java com.sun.tools.ws.WsImport -extension -Xnocompile -s out \
     -wsdllocation http://example.org/hello?wsdl hello.wsdl
javac -proc:none -Xlint:deprecation -Werror -d out/classes $(find out -name '*.java')
```

* before: `warning: [deprecation] URL(String) in URL has been deprecated`, `javac` exits 1
* after: `javac` exits 0

`mvn install` over `jaxws-ri` (through `tools/wscompile`) passes, copyright check included.

No unit test accompanies this: `wscompile`'s existing wsimport tests shell out to Ant in a forked
JVM, and an in-process test cannot run because `WsimportTool.generateCode` trips over a missing
`uses` declaration for `GeneratorBase` — filed separately as #818.
