### PR TITLE
Do not overwrite a configured handler chain with @HandlerChain

### DIFF
--- a/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/server/EndpointFactory.java
+++ b/jaxws-ri/runtime/rt/src/main/java/com/sun/xml/ws/server/EndpointFactory.java
@@ -290,8 +290,12 @@ public class EndpointFactory {
             terminal = createSEIInvokerTube(seiModel,invoker,binding);
         }
 
-        // Process @HandlerChain, if handler-chain is not set via Deployment Descriptor
-        if (processHandlerAnnotation) {
+        // Process @HandlerChain, if a handler chain is not already configured -- either
+        // through a Deployment Descriptor, or programmatically via
+        // Binding.setHandlerChain(..) before the endpoint is published. A chain the
+        // application configured explicitly must not be silently replaced by the
+        // annotation-declared one.
+        if (processHandlerAnnotation && binding.getHandlerChain().isEmpty()) {
             processHandlerAnnotation(binding, implType, serviceName, portName);
         }
         // Selects only required metadata for this endpoint from the passed-in metadata

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/AnnotatedProvider.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/AnnotatedProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.server;
+
+import jakarta.jws.HandlerChain;
+import jakarta.xml.ws.Provider;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.ServiceMode;
+import jakarta.xml.ws.WebServiceProvider;
+import javax.xml.transform.Source;
+
+/**
+ * Endpoint implementor declaring a handler chain through {@code @HandlerChain}, used to
+ * verify how that annotation interacts with a chain configured on the binding beforehand.
+ * Must be public with a public no-arg constructor so that the default
+ * {@code InstanceResolver} can instantiate it.
+ */
+@WebServiceProvider(targetNamespace = "http://server.ws.xml.sun.com/", serviceName = "AnnotatedProviderService", portName = "AnnotatedProviderPort")
+@ServiceMode(value = Service.Mode.PAYLOAD)
+@HandlerChain(file = "test-handler-chain.xml")
+public class AnnotatedProvider implements Provider<Source> {
+
+    @Override
+    public Source invoke(Source request) {
+        return request;
+    }
+}

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/AnnotationDeclaredHandler.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/AnnotationDeclaredHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.xml.ws.server;
+
+import jakarta.xml.ws.handler.LogicalHandler;
+import jakarta.xml.ws.handler.LogicalMessageContext;
+import jakarta.xml.ws.handler.MessageContext;
+
+/**
+ * Handler referenced by {@code test-handler-chain.xml}, used to verify how the
+ * {@code @HandlerChain} annotation interacts with a programmatically configured chain.
+ */
+public class AnnotationDeclaredHandler implements LogicalHandler<LogicalMessageContext> {
+
+    @Override
+    public boolean handleMessage(LogicalMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(LogicalMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+    }
+}

--- a/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/EndpointFactoryTest.java
+++ b/jaxws-ri/runtime/rt/src/test/java/com/sun/xml/ws/server/EndpointFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,9 +10,19 @@
 
 package com.sun.xml.ws.server;
 
+import com.sun.xml.ws.api.BindingID;
+import com.sun.xml.ws.api.WSBinding;
+import com.sun.xml.ws.api.server.WSEndpoint;
+import com.sun.xml.ws.binding.BindingImpl;
 import junit.framework.TestCase;
 
 import jakarta.jws.WebService;
+import jakarta.xml.ws.handler.Handler;
+import jakarta.xml.ws.handler.LogicalHandler;
+import jakarta.xml.ws.handler.LogicalMessageContext;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
 
 public class EndpointFactoryTest extends TestCase {
 
@@ -38,9 +48,62 @@ public class EndpointFactoryTest extends TestCase {
         }
     }
 
+    /**
+     * A handler chain configured on the binding before the endpoint is created must
+     * survive endpoint creation, rather than being replaced by the one declared with
+     * {@code @HandlerChain} on the implementor.
+     */
+    public void testConfiguredHandlerChainSurvivesHandlerChainAnnotation() {
+        WSBinding binding = BindingImpl.create(BindingID.SOAP11_HTTP);
+        Handler<?> configured = new ConfiguredHandler();
+        binding.setHandlerChain(Collections.<Handler>singletonList(configured));
+
+        createEndpoint(binding);
+
+        List<Handler> chain = binding.getHandlerChain();
+        assertEquals(1, chain.size());
+        assertSame(configured, chain.get(0));
+    }
+
+    /**
+     * With no chain configured beforehand, the {@code @HandlerChain} declared one is
+     * still applied, as it always has been.
+     */
+    public void testHandlerChainAnnotationAppliedWhenNoneConfigured() {
+        WSBinding binding = BindingImpl.create(BindingID.SOAP11_HTTP);
+        assertTrue(binding.getHandlerChain().isEmpty());
+
+        createEndpoint(binding);
+
+        List<Handler> chain = binding.getHandlerChain();
+        assertEquals(1, chain.size());
+        assertTrue(chain.get(0) instanceof AnnotationDeclaredHandler);
+    }
+
+    private static void createEndpoint(WSBinding binding) {
+        WSEndpoint.create(AnnotatedProvider.class, true, null, null, null, null, binding,
+                null, null, (URL) null);
+    }
 }
 
 @WebService
 class MyImpl1 { }
 
 class MyImpl2 { }
+
+class ConfiguredHandler implements LogicalHandler<LogicalMessageContext> {
+
+    @Override
+    public boolean handleMessage(LogicalMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(LogicalMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public void close(jakarta.xml.ws.handler.MessageContext context) {
+    }
+}


### PR DESCRIPTION
Fixes #812

## Problem

`EndpointFactory.createEndpoint(..)` reprocesses the `@HandlerChain` annotation whenever `processHandlerAnnotation` is set:

```java
// Process @HandlerChain, if handler-chain is not set via Deployment Descriptor
if (processHandlerAnnotation) {
    processHandlerAnnotation(binding, implType, serviceName, portName);
}
```

and `processHandlerAnnotation(..)` applies the annotation-declared chain unconditionally:

```java
if (chainInfo != null) {
    binding.setHandlerChain(chainInfo.getHandlers());
    ...
}
```

So a chain the application configured through `Binding.setHandlerChain(..)` before `Endpoint.publish(..)` is replaced, with no exception and no warning. `EndpointImpl.createEndpoint(String)` passes `processHandlerAnnotation = true` unconditionally, so an application using the public API has no way to opt out.

The comment on that guard already describes the intended semantics — apply the annotation *if a chain is not already set* — but the condition only tests the boolean flag.

## Fix

Also require that the binding has no chain yet:

```java
if (processHandlerAnnotation && binding.getHandlerChain().isEmpty()) {
```

`WSBinding.getHandlerChain()` is declared `@NotNull`, and `BindingImpl` initialises its `HandlerConfiguration` with an empty handler list, so the check is safe on a freshly created binding. When nothing was configured beforehand — the common case, including deployment-descriptor-driven configuration, which passes `processHandlerAnnotation = false` anyway — behaviour is unchanged.

This is the first of the two options on the issue. I did not attempt the second (merging the annotation-declared and programmatic chains), since as the reporter notes it needs a documented public API to express ordering, which is a design decision rather than a bug fix. The separate observation on the issue — that changing the chain *after* `publish()` does not affect an already-assembled pipeline — is also untouched here.

## Testing

Two cases in `EndpointFactoryTest`, both driving the real `WSEndpoint.create(..)` against a `@WebServiceProvider` implementor annotated with `@HandlerChain`:

- `testConfiguredHandlerChainSurvivesHandlerChainAnnotation` — a chain set on the binding beforehand is still there afterwards.
- `testHandlerChainAnnotationAppliedWhenNoneConfigured` — with nothing configured, the annotation-declared handler is applied, as before.

Verified with a negative control: reverting only `EndpointFactory` and keeping the tests fails the first with

```
expected same:<com.sun.xml.ws.server.ConfiguredHandler@...> was not:<com.sun.xml.ws.server.AnnotationDeclaredHandler@...>
```

which is the silent replacement this issue reports, while the second keeps passing.

Run with `mvn -pl runtime/rt -am -Dtest=EndpointFactoryTest test` from `jaxws-ri`.
